### PR TITLE
Added missing include fixing Windows build

### DIFF
--- a/include/luxcore/luxcore.h
+++ b/include/luxcore/luxcore.h
@@ -42,6 +42,7 @@
 #include <string>
 
 #include <luxcore/cfg.h>
+#include <luxrays/utils/utils.h>
 #include <luxrays/utils/exportdefs.h>
 #include <luxrays/utils/properties.h>
 #include <luxrays/utils/cyhair/cyHairFile.h>


### PR DESCRIPTION
Fixes the following error when compiling with Windows:
```
C:\development\LuxCoreRender\LuxCore\include\luxcore/luxcore.h(275): error C4430: missing type specifier - int assumed. Note: C++ does not support default-int
C:\development\LuxCoreRender\LuxCore\include\luxcore/luxcore.h(275): error C2146: syntax error : missing ',' before identifier 'imagePipelineIndex' (C:\development\LuxCoreRender\LuxCore\src\luxcore\luxparser\luxparse.cpp)
```

Am I on the correct branch?