### PR TITLE
raise cmake_minimum_required to version 3.6

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,7 @@ MESSAGE(STATUS "CMake version " ${CMAKE_VERSION} " detected")
 #
 ################################################################################
 
-cmake_minimum_required(VERSION 3.0)
+cmake_minimum_required(VERSION 3.6)
 cmake_policy(VERSION 3.0)
 
 # Remove the following when the version check is at least 2.8.4


### PR DESCRIPTION
We are now using the FILTER command, which requires cmake 3.6.
Related: LuxCoreRender/WindowsCompile/issues/1