### PR TITLE
Fixed bug that was preventing load of an lxs file using texture with emission

### DIFF
--- a/src/luxcore/luxparser/luxparse.y
+++ b/src/luxcore/luxparser/luxparse.y
@@ -432,10 +432,7 @@ static void DefineMaterial(const string &name, const Properties &matProps, const
 				Property(prefix + ".emission.gain")(Spectrum(lightProps.Get(Property("gain")(1.f)).Get<float>())) <<
 				Property(prefix + ".emission.power")(lightProps.Get(Property("power")(100.f)).Get<float>()) <<
 				Property(prefix + ".emission.efficency")(lightProps.Get(Property("efficency")(17.f)).Get<float>()) <<
-				Property(prefix + ".emission.id")(currentGraphicsState.currentLightGroup) <<
-				Property(prefix + ".emission.mapfile")(lightProps.Get(Property("mapname")("")).Get<string>()) <<
-				Property(prefix + ".emission.iesfile")(lightProps.Get(Property("iesname")("")).Get<string>()) <<
-				Property(prefix + ".emission.flipz")(lightProps.Get(Property("flipz")(false)).Get<bool>());
+				Property(prefix + ".emission.id")(currentGraphicsState.currentLightGroup);
 	}
 }
 


### PR DESCRIPTION
Never contributed to luxcorerender before, but this bug was bothering me.

The issue was that any lxs file using texture emission as a light source would cause luxcorerender to throw an "Invalid IES file in property ..." error. Since this broke pretty much any scene with a mesh light, it was a pretty big block to running old luxrender scenes in luxcorerender.

There were two issues causing this to happen. I would argue that they were both bugs, but I certainly might have missed something.

----- 1 ------
parselights.cpp was throwing a runtime exception whenever it encountered:
  A -  a scene with a defined IES property but invalid (e.g. empty) IES data; or 
  B -  a scene with a defined mapfile property but empty mapfile path.

This caused luxcorerender to exit if a .iesfile property or .mapfile property was initialized with an empty-string (which was happening in the lxs parser).

I think this behavior was a bug; I don't think a runtime exception was appropriate in either of these cases - a scene can generally be rendered without IES or a map. 

My fix was to log the invalid iesdata or mapfile, but continue with the scene load. I think this behavior makes much more sense

----- 2 -----
luxparse.y was initializing emission textures to have .mapfile and .iesfile properties with empty strings. This, coupled with 1, caused all lxs files using emission to break. This is a pretty clear bug - I assume it was introduced by someone who thought initializing to empty-string was the correct way to indicate that ies/map was not being used.

My fix was to remove the initialization of the .mapfile, .iesfile, and .flipz properties. If we are going to log when IES/map is defined but invalid, we should avoid initializing the properties as empty strings.

Please let me know if I missed anything, or if either of these behaviors are not actually bugs.
Best,
Theodore