### PR TITLE
Maint/update macos build

### DIFF
--- a/cmake/PlatformSpecific.cmake
+++ b/cmake/PlatformSpecific.cmake
@@ -217,6 +217,8 @@ IF(APPLE)
 	else() # replace CMAKE_BUILD_TYPE with XCode env var $(CONFIGURATION) globally
 		SET(CMAKE_BUILD_TYPE "$(CONFIGURATION)" )
 	endif()
+        SET(CMAKE_BUILD_RPATH "@loader_path")
+        SET(CMAKE_INSTALL_RPATH "@loader_path")
 	#### OSX-flags by jensverwiebe
 	ADD_DEFINITIONS(-Wall -DHAVE_PTHREAD_H) # global compile definitions
 	ADD_DEFINITIONS(-fvisibility=hidden -fvisibility-inlines-hidden)

--- a/cmake/SpecializedConfig/Config_OSX.cmake
+++ b/cmake/SpecializedConfig/Config_OSX.cmake
@@ -17,12 +17,17 @@ set(OSX_SEARCH_PATH     ${OSX_DEPENDENCY_ROOT})
 # Libs present in system ( /usr )
 SET(SYS_LIBRARIES z )
 
-find_package(PythonLibs 3.5 REQUIRED)
+execute_process(COMMAND python3 -c "from distutils.sysconfig import get_python_inc; print(get_python_inc())" OUTPUT_VARIABLE PY3_INCLUDE)
+execute_process(COMMAND python3 -c "import distutils.sysconfig as sysconfig; print(sysconfig.get_config_var('LIBDIR'))" OUTPUT_VARIABLE PY3_LIB)
+SET(PYTHON_LIBRARIES ${PY3_LIB})
+SET(PYTHON_INCLUDE_DIRS ${PY3_INCLUDE})
+SET(PYTHONLIBS_FOUND TRUE)
 
 #Find pyside2-uic so that .ui files rebuild pyside deps
+execute_process(COMMAND python3 -c "import sys; print(sys.base_exec_prefix)" OUTPUT_VARIABLE PY_EXEC_PREFIX)
 find_program(PYSIDE_UIC
              NAME pyside2-uic
-             HINTS /usr/local/bin/)
+             HINTS ${PY_EXEC_PREFIX}/bin/)
 
 # Libs that have find_package modules
 set(OPENIMAGEIO_ROOT_DIR "${OSX_SEARCH_PATH}")
@@ -37,6 +42,8 @@ set(OPENCL_LIBRARYDIR         "${OPENCL_SEARCH_PATH}")
 set(EMBREE_SEARCH_PATH			"${OSX_SEARCH_PATH}")
 
 set(TBB_SEARCH_PATH "${OSX_SEARCH_PATH}")
+INSTALL(FILES ${OSX_SEARCH_PATH}/lib/libtbb.dylib DESTINATION lib)
+INSTALL(FILES ${OSX_SEARCH_PATH}/lib/libtbbmalloc.dylib DESTINATION lib)
 set(BLOSC_SEARCH_PATH "${OSX_SEARCH_PATH}")
 
 find_library(OPENMP_LIB libiomp5.dylib HINTS ${OSX_SEARCH_PATH}/lib)
@@ -48,6 +55,8 @@ else()
     set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
     set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L${OPENMP_LIB} -liomp5")
     set(CMAKE_MODULE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -L${OPENMP_LIB} -liomp5")
+    INSTALL(FILES ${OSX_SEARCH_PATH}/lib/libomp.dylib DESTINATION lib)
+    INSTALL(FILES ${OSX_SEARCH_PATH}/lib/libiomp5.dylib DESTINATION lib)
 endif()
 
 set(GLEW_SEARCH_PATH          "${OSX_SEARCH_PATH}")
@@ -73,3 +82,5 @@ SET(PNG_FOUND ON)
 SET(EMBREE_LIBRARY ${OSX_DEPENDENCY_ROOT}/lib/libembree3.dylib)
 SET(EMBREE_INCLUDE_PATH ${OSX_DEPENDENCY_ROOT}/include/embree3)
 SET(EMBREE_FOUND ON)
+INSTALL(FILES ${OSX_DEPENDENCY_ROOT}/lib/libembree3.dylib DESTINATION lib)
+INSTALL(FILES ${OSX_DEPENDENCY_ROOT}/lib/libembree3.3.dylib DESTINATION lib)

--- a/samples/pysideluxcoredemo/pysideluxcoredemo.py
+++ b/samples/pysideluxcoredemo/pysideluxcoredemo.py
@@ -29,6 +29,7 @@ try:
 	import PySide.QtCore as QtCore
 	import PySide.QtGui as QtGui
 	import PySide.QtGui as QtWidgets
+        PYSIDE2 = False
 except ImportError:
 	from PySide2 import QtGui, QtCore, QtWidgets
 	PYSIDE2 = True
@@ -176,7 +177,7 @@ class RenderView(QMainWindow):
 	def center(self):
 		screen = QDesktopWidget().screenGeometry()
 		size =  self.geometry()
-		if not PYSIDE2
+		if not PYSIDE2:
 			self.move((screen.width() - size.width()) / 2, (screen.height() - size.height()) / 2)
 	
 	def saveImage(self):


### PR DESCRIPTION
This pull request updates the cmake build in OS X to use pyenv so that the python and numpy versions can be set to the ones used in blender which is older than the currently available ones on MacOS. This pull request also fixes a missing colon for checking PYSIDE2 in the sample demo.