### PR TITLE
Update Mac OS Deps for Embree 3.2.4

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -8,6 +8,6 @@ if [[ $TRAVIS_OS_NAME == 'osx' ]]; then
   brew install pyside
   brew install numpy --with-python3
   #Install Deps
-  wget https://github.com/LuxCoreRender/MacOSCompileDeps/releases/download/luxcorerender_v2.1alpha4/MacDistFiles.tar.gz
+  wget https://github.com/LuxCoreRender/MacOSCompileDeps/releases/download/luxcorerender_v2.1beta2/MacDistFiles.tar.gz
   tar xzf MacDistFiles.tar.gz
 fi


### PR DESCRIPTION
This pull request updates the dependencies for Mac OS so that Embree 3.2.4 is used. Travis CI was updated rather than adding Azure due to #156 bugs causing tests to fail which would be run after migrating to Azure.