### PR TITLE
Fix build with OpenImageIO 1.9.0

### DIFF
--- a/include/luxcore/pyluxcore/pyluxcoreutils.h
+++ b/include/luxcore/pyluxcore/pyluxcoreutils.h
@@ -32,7 +32,7 @@ namespace luxcore {
 template <typename T> boost::python::object TransferToPython(T *t) {
 	// Transfer ownership to a smart pointer, allowing for proper cleanup
 	// incase Boost.Python throws.
-	std::auto_ptr<T> ptr(t);
+	std::unique_ptr<T> ptr(t);
 
 	// Use the manage_new_object generator to transfer ownership to Python.
 	typename boost::python::manage_new_object::apply<T *>::type converter;

--- a/samples/luxcoreui/luxcoreui.cpp
+++ b/samples/luxcoreui/luxcoreui.cpp
@@ -37,10 +37,10 @@ using namespace luxcore;
 #include <OpenImageIO/dassert.h>
 
 static void ConvertImage(const string &fileName) {
-	auto_ptr<ImageInput> in(ImageInput::open(fileName));
+	unique_ptr<ImageInput> in(ImageInput::open(fileName));
 	
 	const ImageSpec &spec = in->spec();
-	auto_ptr<u_char> pixels(new u_char[spec.width * spec.height * spec.nchannels] );
+	unique_ptr<u_char> pixels(new u_char[spec.width * spec.height * spec.nchannels] );
 
 	in->read_image(TypeDesc::UCHAR, pixels.get());
 

--- a/src/luxcore/luxcoreimpl.cpp
+++ b/src/luxcore/luxcoreimpl.cpp
@@ -876,8 +876,8 @@ RenderSessionImpl::RenderSessionImpl(const RenderConfigImpl *config, const std::
 		renderConfig(config) {
 	film = new FilmImpl(*this);
 
-	auto_ptr<slg::Film> startFilm(slg::Film::LoadSerialized(startFilmFileName));
-	auto_ptr<slg::RenderState> startState(slg::RenderState::LoadSerialized(startStateFileName));
+	unique_ptr<slg::Film> startFilm(slg::Film::LoadSerialized(startFilmFileName));
+	unique_ptr<slg::RenderState> startState(slg::RenderState::LoadSerialized(startStateFileName));
 
 	renderSession = new slg::RenderSession(config->renderConfig,
 			startState.release(), startFilm.release());

--- a/src/luxcore/pyluxcoreforblender.cpp
+++ b/src/luxcore/pyluxcoreforblender.cpp
@@ -873,7 +873,7 @@ bool Scene_DefineBlenderStrands(luxcore::detail::SceneImpl *scene,
 	if (uvArraySize > 0 && !imageFilename.empty()) {
 		ImageSpec config;
 		config.attribute ("oiio:UnassociatedAlpha", 1);
-		auto_ptr<ImageInput> in(ImageInput::open(imageFilename, &config));
+		unique_ptr<ImageInput> in(ImageInput::open(imageFilename, &config));
 		
 		if (!in.get()) {
 			throw runtime_error("Error opening image file : " + imageFilename +

--- a/src/slg/engines/pathoclbase/pathoclbase.cpp
+++ b/src/slg/engines/pathoclbase/pathoclbase.cpp
@@ -133,7 +133,7 @@ PathOCLBaseRenderEngine::~PathOCLBaseRenderEngine() {
 }
 
 void PathOCLBaseRenderEngine::InitPixelFilterDistribution() {
-	auto_ptr<Filter> pixelFilter(renderConfig->AllocPixelFilter());
+	unique_ptr<Filter> pixelFilter(renderConfig->AllocPixelFilter());
 
 	// Compile sample distribution
 	delete[] pixelFilterDistribution;

--- a/src/slg/engines/tilerepository.cpp
+++ b/src/slg/engines/tilerepository.cpp
@@ -95,7 +95,7 @@ void Tile::InitTileFilm(const Film &film, Film **tileFilm) {
 
 	// Build an image pipeline with only an auto-linear tone mapping and
 	// gamma correction.
-	auto_ptr<ImagePipeline> imagePipeline(new ImagePipeline());
+	unique_ptr<ImagePipeline> imagePipeline(new ImagePipeline());
 	imagePipeline->AddPlugin(new LinearToneMap(1.f));
 	imagePipeline->AddPlugin(new GammaCorrectionPlugin(2.2f));
 	(*tileFilm)->SetImagePipelines(imagePipeline.release());
@@ -639,7 +639,7 @@ TileRepository *TileRepository::FromProperties(const luxrays::Properties &cfg) {
 		tileWidth = tileHeight = Max(8u, cfg.Get(GetDefaultProps().Get("tile.size")).Get<u_int>());
 	tileWidth = Max(8u, cfg.Get(Property("tile.size.x")(tileWidth)).Get<u_int>());
 	tileHeight = Max(8u, cfg.Get(Property("tile.size.y")(tileHeight)).Get<u_int>());
-	auto_ptr<TileRepository> tileRepository(new TileRepository(tileWidth, tileHeight));
+	unique_ptr<TileRepository> tileRepository(new TileRepository(tileWidth, tileHeight));
 
 	tileRepository->maxPassCount = cfg.Get(Property("batch.haltdebug")(0)).Get<u_int>();
 	tileRepository->enableMultipassRendering = cfg.Get(GetDefaultProps().Get("tile.multipass.enable")).Get<bool>();

--- a/src/slg/film/filmparse.cpp
+++ b/src/slg/film/filmparse.cpp
@@ -471,7 +471,7 @@ ImagePipeline *Film::CreateImagePipeline(const Properties &props, const string &
 	//--------------------------------------------------------------------------
 
 	const u_int keyFieldCount = Property::CountFields(imagePipelinePrefix);
-	auto_ptr<ImagePipeline> imagePipeline(new ImagePipeline());
+	unique_ptr<ImagePipeline> imagePipeline(new ImagePipeline());
 
 	vector<string> imagePipelineKeys = props.GetAllUniqueSubNames(imagePipelinePrefix);
 	if (imagePipelineKeys.size() > 0) {

--- a/src/slg/film/filmproperties.cpp
+++ b/src/slg/film/filmproperties.cpp
@@ -109,7 +109,7 @@ Film *Film::FromProperties(const Properties &cfg) {
 	SLG_LOG("Film resolution: " << filmFullWidth << "x" << filmFullHeight);
 	if (filmSubRegionUsed)
 		SLG_LOG("Film sub-region: " << filmSubRegion[0] << " " << filmSubRegion[1] << filmSubRegion[2] << " " << filmSubRegion[3]);
-	auto_ptr<Film> film(new Film(filmFullWidth, filmFullHeight,
+	unique_ptr<Film> film(new Film(filmFullWidth, filmFullHeight,
 			filmSubRegionUsed ? filmSubRegion : NULL));
 
 	// For compatibility with the past
@@ -130,7 +130,7 @@ Film *Film::FromProperties(const Properties &cfg) {
 	// Add the default image pipeline
 	//--------------------------------------------------------------------------
 
-	auto_ptr<ImagePipeline> imagePipeline(new ImagePipeline());
+	unique_ptr<ImagePipeline> imagePipeline(new ImagePipeline());
 	imagePipeline->AddPlugin(new AutoLinearToneMap());
 	imagePipeline->AddPlugin(new GammaCorrectionPlugin(2.2f));
 

--- a/src/slg/imagemap/imagemap.cpp
+++ b/src/slg/imagemap/imagemap.cpp
@@ -493,7 +493,7 @@ void ImageMapStorageImpl<T, CHANNELS>::ReverseGammaCorrection(const float gamma)
 template <class T, u_int CHANNELS>
 ImageMapStorage *ImageMapStorageImpl<T, CHANNELS>::Copy() const {
 	const u_int pixelCount = width * height;
-	auto_ptr<ImageMapPixel<T, CHANNELS> > newPixels(new ImageMapPixel<T, CHANNELS>[pixelCount]);
+	unique_ptr<ImageMapPixel<T, CHANNELS>[]> newPixels(new ImageMapPixel<T, CHANNELS>[pixelCount]);
 
 	const ImageMapPixel<T, CHANNELS> *src = pixels;
 	ImageMapPixel<T, CHANNELS> *dst = newPixels.get();
@@ -524,7 +524,7 @@ ImageMapStorage *ImageMapStorageImpl<T, CHANNELS>::SelectChannel(const ChannelSe
 				// Nothing to do
 				return NULL;
 			} else if (CHANNELS == 2) {
-				auto_ptr<ImageMapPixel<T, 1> > newPixels(new ImageMapPixel<T, 1>[pixelCount]);
+				unique_ptr<ImageMapPixel<T, 1>[]> newPixels(new ImageMapPixel<T, 1>[pixelCount]);
 
 				const ImageMapPixel<T, CHANNELS> *src = pixels;
 				ImageMapPixel<T, 1> *dst = newPixels.get();
@@ -542,7 +542,7 @@ ImageMapStorage *ImageMapStorageImpl<T, CHANNELS>::SelectChannel(const ChannelSe
 
 				return new ImageMapStorageImpl<T, 1>(newPixels.release(), width, height, wrapType);
 			} else {
-				auto_ptr<ImageMapPixel<T, 1> > newPixels(new ImageMapPixel<T, 1>[pixelCount]);
+				unique_ptr<ImageMapPixel<T, 1>[]> newPixels(new ImageMapPixel<T, 1>[pixelCount]);
 
 				const ImageMapPixel<T, CHANNELS> *src = pixels;
 				ImageMapPixel<T, 1> *dst = newPixels.get();
@@ -564,7 +564,7 @@ ImageMapStorage *ImageMapStorageImpl<T, CHANNELS>::SelectChannel(const ChannelSe
 				// Nothing to do
 				return NULL;
 			} else if (CHANNELS == 2) {
-				auto_ptr<ImageMapPixel<T, 1> > newPixels(new ImageMapPixel<T, 1>[pixelCount]);
+				unique_ptr<ImageMapPixel<T, 1>[]> newPixels(new ImageMapPixel<T, 1>[pixelCount]);
 
 				const ImageMapPixel<T, CHANNELS> *src = pixels;
 				ImageMapPixel<T, 1> *dst = newPixels.get();
@@ -579,7 +579,7 @@ ImageMapStorage *ImageMapStorageImpl<T, CHANNELS>::SelectChannel(const ChannelSe
 
 				return new ImageMapStorageImpl<T, 1>(newPixels.release(), width, height, wrapType);
 			} else {
-				auto_ptr<ImageMapPixel<T, 1> > newPixels(new ImageMapPixel<T, 1>[pixelCount]);
+				unique_ptr<ImageMapPixel<T, 1>[]> newPixels(new ImageMapPixel<T, 1>[pixelCount]);
 
 				const ImageMapPixel<T, CHANNELS> *src = pixels;
 				ImageMapPixel<T, 1> *dst = newPixels.get();
@@ -597,7 +597,7 @@ ImageMapStorage *ImageMapStorageImpl<T, CHANNELS>::SelectChannel(const ChannelSe
 
 						src++;
 						dst++;
-					}							
+					}
 				}
 
 				return new ImageMapStorageImpl<T, 1>(newPixels.release(), width, height, wrapType);
@@ -608,7 +608,7 @@ ImageMapStorage *ImageMapStorageImpl<T, CHANNELS>::SelectChannel(const ChannelSe
 				// Nothing to do
 				return NULL;
 			} else {
-				auto_ptr<ImageMapPixel<T, 3> > newPixels(new ImageMapPixel<T, 3>[pixelCount]);
+				unique_ptr<ImageMapPixel<T, 3>[]> newPixels(new ImageMapPixel<T, 3>[pixelCount]);
 
 				const ImageMapPixel<T, CHANNELS> *src = pixels;
 				ImageMapPixel<T, 3> *dst = newPixels.get();
@@ -628,7 +628,7 @@ ImageMapStorage *ImageMapStorageImpl<T, CHANNELS>::SelectChannel(const ChannelSe
 				// Nothing to do
 				return NULL;
 			} else {
-				auto_ptr<ImageMapPixel<T, 3> > newPixels(new ImageMapPixel<T, 3>[pixelCount]);
+				unique_ptr<ImageMapPixel<T, 3>[]> newPixels(new ImageMapPixel<T, 3>[pixelCount]);
 
 				const ImageMapPixel<T, CHANNELS> *src = pixels;
 				ImageMapPixel<T, 3> *dst = newPixels.get();
@@ -674,7 +674,7 @@ ImageMap::ImageMap(const string &fileName, const float g,
 	else {
 		ImageSpec config;
 		config.attribute ("oiio:UnassociatedAlpha", 1);
-		auto_ptr<ImageInput> in(ImageInput::open(resolvedFileName, &config));
+		unique_ptr<ImageInput> in(ImageInput::open(resolvedFileName, &config));
 		if (in.get()) {
 			const ImageSpec &spec = in->spec();
 
@@ -735,7 +735,7 @@ ImageMap::ImageMap(const string &fileName, const float g,
 		pixelStorage->wrapType = wrapType;
 		pixelStorage->ReverseGammaCorrection(gamma);
 	}
-	
+
 	Preprocess();
 }
 
@@ -774,7 +774,7 @@ float ImageMap::CalcSpectrumMean() const {
 float ImageMap::CalcSpectrumMeanY() const {
 	const u_int pixelCount = pixelStorage->width * pixelStorage->height;
 
-	float mean = 0.f;	
+	float mean = 0.f;
 	#pragma omp parallel for reduction(+:mean)
 	for (
 			// Visual C++ 2013 supports only OpenMP 2.5
@@ -840,7 +840,7 @@ void ImageMap::Resize(const u_int newWidth, const u_int newHeight) {
 		default:
 			throw runtime_error("Unsupported storage type in ImageMap::Resize(): " + ToString(storageType));
 	}
-	
+
 	ImageSpec sourceSpec(width, height, channelCount, baseType);
 	ImageBuf source(sourceSpec, (void *)pixelStorage->GetPixelsData());
 
@@ -871,8 +871,8 @@ void ImageMap::Resize(const u_int newWidth, const u_int newHeight) {
 		default:
 			throw runtime_error("Unsupported storage type in ImageMap::Resize(): " + ToString(storageType));
 	}
-	
-	dest.get_pixels(0, newWidth, 0, newHeight, 0, 1, baseType, pixelStorage->GetPixelsData());
+
+	dest.get_pixels(roi, baseType, pixelStorage->GetPixelsData());
 
 	Preprocess();
 }
@@ -892,7 +892,7 @@ string ImageMap::GetFileExtension() const {
 }
 
 void ImageMap::WriteImage(const string &fileName) const {
-	ImageOutput *out = ImageOutput::create(fileName);
+	unique_ptr<ImageOutput> out = ImageOutput::create(fileName);
 	if (out) {
 		ImageMapStorage::StorageType storageType = pixelStorage->GetStorageType();
 
@@ -918,7 +918,7 @@ void ImageMap::WriteImage(const string &fileName) const {
 					const u_int size = pixelStorage->width * pixelStorage->height;
 					const float *srcBuffer = (float *)pixelStorage->GetPixelsData();
 					float *tmpBuffer = new float[size * 3];
-					
+
 					float *tmpBufferPtr = tmpBuffer;
 					for (u_int i = 0; i < size; ++i) {
 						const float v = srcBuffer[i];
@@ -945,7 +945,6 @@ void ImageMap::WriteImage(const string &fileName) const {
 				throw runtime_error("Unsupported storage type in ImageMap::WriteImage(): " + ToString(storageType));
 		}
 
-		delete out;
 	} else
 		throw runtime_error("Failed image save: " + fileName);
 }
@@ -967,7 +966,7 @@ ImageMap *ImageMap::Merge(const ImageMap *map0, const ImageMap *map1, const u_in
 				mergedImg[x + y * width] = map0->GetFloat(uv) * map1->GetFloat(uv);
 			}
 		}
-		
+
 		imgMap->Preprocess();
 
 		return imgMap;

--- a/src/slg/renderconfig.cpp
+++ b/src/slg/renderconfig.cpp
@@ -59,7 +59,7 @@ using namespace slg;
 //------------------------------------------------------------------------------
 
 static boost::mutex defaultPropertiesMutex;
-static auto_ptr<Properties> defaultProperties;
+static unique_ptr<Properties> defaultProperties;
 
 BOOST_CLASS_EXPORT_IMPLEMENT(slg::RenderConfig)
 

--- a/src/slg/scene/parsecamera.cpp
+++ b/src/slg/scene/parsecamera.cpp
@@ -74,7 +74,7 @@ Camera *Scene::CreateCamera(const Properties &props) {
 	SDL_LOG("Camera position: " << orig);
 	SDL_LOG("Camera target: " << target);
 
-	auto_ptr<Camera> camera;
+	unique_ptr<Camera> camera;
 	if ((type == "environment") || (type == "orthographic") || (type == "perspective") || (type == "stereo")) {
 		if (type == "orthographic") {
 			OrthographicCamera *orthoCamera;

--- a/tests/luxcoreimplserializationdemo/luxcoreimplserializationdemo.cpp
+++ b/tests/luxcoreimplserializationdemo/luxcoreimplserializationdemo.cpp
@@ -117,7 +117,7 @@ static void TestFilmSerialization() {
 
 	// Read the film
 	SLG_LOG("Read the film");
-	auto_ptr<Film> filmCopy(Film::LoadSerialized("film.flm"));
+	unique_ptr<Film> filmCopy(Film::LoadSerialized("film.flm"));
 	filmCopy->oclEnable = false;
 	
 	filmCopy->ExecuteImagePipeline(0);
@@ -230,7 +230,7 @@ static void TestSceneSerialization() {
 
 	// Read the scene
 	SLG_LOG("Read the scene");
-	auto_ptr<Scene> sceneCopy(Scene::LoadSerialized("scene.bsc"));
+	unique_ptr<Scene> sceneCopy(Scene::LoadSerialized("scene.bsc"));
 }
 
 static void TestRenderConfigSerialization() {
@@ -247,7 +247,7 @@ static void TestRenderConfigSerialization() {
 
 	// Read the scene
 	SLG_LOG("Read the render configuration");
-	auto_ptr<RenderConfig> config(RenderConfig::LoadSerialized("renderconfig.bcf"));
+	unique_ptr<RenderConfig> config(RenderConfig::LoadSerialized("renderconfig.bcf"));
 }
 
 int main(int argc, char *argv[]) {


### PR DESCRIPTION
OIIO plugin version 22 changed the signatures of ImageInput/ImageOutput
create() to return unique_ptr. (OIIO 1.9)

This is needed for Fedora which ships OpenImageIO 2.0.7

Signed-off-by: Robert-André Mauchin <zebob.m@gmail.com>