### PR TITLE
Fix PySide imports in pysideluxcoredemo

### DIFF
--- a/samples/pysideluxcoredemo/pysideluxcoredemo.py
+++ b/samples/pysideluxcoredemo/pysideluxcoredemo.py
@@ -26,12 +26,13 @@ from functools import partial
 
 import pyluxcore
 try:
-	import PySide.QtCore as QtCore
-	import PySide.QtGui as QtGui
-	import PySide.QtGui as QtWidgets
-        PYSIDE2 = False
+	from PySide.QtCore import *
+	from PySide.QtGui import *
+	PYSIDE2 = False
 except ImportError:
-	from PySide2 import QtGui, QtCore, QtWidgets
+	from PySide2.QtCore import *
+	from PySide2.QtGui import *
+	from PySide2.QtWidgets import *
 	PYSIDE2 = True
 
 class RenderView(QMainWindow):


### PR DESCRIPTION
I'm not sure how this went unnoticed for so long: the pysideluxcoredemo.py doesn't work.

* Addresses a syntax error where tabs and spaces where mixed, which tripped the parser (introduced by #142).
* Changes the imports back (to wildcards), as the new code imported the modules, but referred to classes without specifying which module to find them in (introduced by #140).
* Cleaned up the import logic, so that `PySide.QtGui` isn't imported twice (introduced by #140).

**I was only able to test the PySide2 version! Someone else will have to test for the original PySide / Qt4 imports.**

*I did notice two minor issues during testing (where the ball and the shell can sometimes misalign + toggling the shell is broken), but I'm assuming it's an independent / separate issue, that I'll report / fix later (in a separate PR).*