### PR TITLE
Ignore CL_PLATFORM_NOT_FOUND_KHR error during context initialization

### DIFF
--- a/src/luxrays/core/context.cpp
+++ b/src/luxrays/core/context.cpp
@@ -44,7 +44,14 @@ Context::Context(LuxRaysDebugHandler handler, const Properties &config) : cfg(co
 #if !defined(LUXRAYS_DISABLE_OPENCL)
 	// Platform info
 	VECTOR_CLASS<cl::Platform> platforms;
-	cl::Platform::get(&platforms);
+	try {
+		cl::Platform::get(&platforms);
+	} catch (cl::Error &err) {
+		// The cl_khr_icd extension throws exceptions if zero platforms are available.
+		// We ignore that error (OpenCL is optional), but throw anything else.
+		if (err.err() != CL_PLATFORM_NOT_FOUND_KHR)
+			throw;
+	}
 	for (size_t i = 0; i < platforms.size(); ++i)
 		LR_LOG(this, "OpenCL Platform " << i << ": " << platforms[i].getInfo<CL_PLATFORM_VENDOR>().c_str());
 


### PR DESCRIPTION
Closes #191 - the OpenCL headers (at compile time) + ICD loader (at runtime) are still necessary if OpenCL is enabled, but no OpenCL device driver (platform) is required at runtime.

The original code was designed to work this way, but an issue was caused by a change in https://www.khronos.org/registry/OpenCL/extensions/khr/cl_khr_icd.txt:

>   "clGetPlatformIDs returns CL_SUCCESS if the function is executed successfully and there are a non zero number of platforms available.
>    It returns CL_PLATFORM_NOT_FOUND_KHR if zero platforms are available.
>    It returns CL_INVALID_VALUE if <num_entries> is equal to zero and <platforms> is not NULL or if both <num_platforms> and <platforms> are NULL."

The original behaviour (prior to this extension) was to always return `CL_SUCCESS` except on parameter errors.

As the C++ wrapper treats all non-`CL_SUCCESS` return values as error, this new return value gets thrown if the user has OpenCL using an ICD loader, but without any device drivers.

The sane solution is to just ignore this error; the platform array will have size 0, just as before.

*I did test this particular exception on Linux; ~~however, I did not test this change with an OpenCL device driver yet; I'll try it with beignet later.~~ I did also test with beignet, but it crashes on my Intel HD4000 - which is to be expected (as confirmed by other posts about this independent issue). So everything should be fine.*