### PR TITLE
update azure to Xcode 11.2 and OIDN to 1.2.0

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -5,7 +5,7 @@
 # To trigger an official release, add a commit tagged in the form "luxcorerender_v*"
 # The "version_string" after the "_" in the tag is used in following steps
 # to generate binary names like "luxcorerender-<version_string>-<platform>-..."
-# One, and only one, tag in the form "luxcorerender_v*" is needed, 
+# One, and only one, tag in the form "luxcorerender_v*" is needed,
 # otherwise the official release build aborts.
 
 variables:
@@ -22,7 +22,7 @@ jobs:
   timeoutInMinutes: 0
   pool:
     vmImage: 'ubuntu-18.04'
-    
+
   steps:
   - script: ./scripts/azurepipeline/detect-build-type.sh
     displayName: Detecting release type (daily, alpha, beta or final)
@@ -33,8 +33,8 @@ jobs:
       artifactName: LuxCore
     displayName: 'Upload github_release_title'
     condition: eq(variables['System.PullRequest.IsFork'], 'False')
-    
-    
+
+
 #==============================================================================
 # Linux binaries
 #==============================================================================
@@ -174,6 +174,10 @@ jobs:
     displayName: Building LuxCore
   - script: ./scripts/azurepipeline/macos/test.sh
     displayName: Testing LuxCore
+  - task: InstallAppleCertificate@2
+    inputs:
+      certSecureFile: LuxCore.q3de.com.p12
+      certPW: LuxCodeSigning
   - script: ./scripts/azurepipeline/macos/pack.sh
     displayName: Packing DiskImages
   - task: PublishBuildArtifacts@1
@@ -191,10 +195,10 @@ jobs:
 # recreated at the current commit by the following release pipeline
 # Runs only if:
 # - this is a daily build
-# - at least one of the build jobs was successful 
+# - at least one of the build jobs was successful
 # - the pipeline has been triggered by master branch and not by a pull request
 - job: DeleteLatestTag
-  dependsOn: 
+  dependsOn:
   - DetectBuildType
   - LuxCoreRenderLinux
   - LuxCoreRenderWindows
@@ -214,7 +218,7 @@ jobs:
   timeoutInMinutes: 0
   pool:
     vmImage: 'ubuntu-18.04'
-    
+
   steps:
   - task: InstallSSHKey@0
     inputs:

--- a/cmake/PlatformSpecific.cmake
+++ b/cmake/PlatformSpecific.cmake
@@ -153,22 +153,16 @@ ENDIF(MSVC)
 
 IF(APPLE)
 
-  SET(AZURE 1) # Set 0 when compiled locally and not on azure
-  
   CMAKE_MINIMUM_REQUIRED(VERSION 3.12) # Required for FindBoost 1.67.0
 
 	########## OS and hardware detection ###########
 
 	EXECUTE_PROCESS(COMMAND uname -r OUTPUT_VARIABLE MAC_SYS) # check for actual system-version
 
-	SET(CMAKE_OSX_DEPLOYMENT_TARGET 10.13) # Minimum OS requirements for LuxCore
+	SET(CMAKE_OSX_DEPLOYMENT_TARGET 10.9) # Minimum OS requirements for LuxCore
 
-    IF(${MAC_SYS} MATCHES 18)
-        IF(AZURE)
-            SET(OSX_SYSTEM 10.14)
-        ELSE()
-            SET(OSX_SYSTEM 10.15)
-        ENDIF()
+  IF(${MAC_SYS} MATCHES 18)
+    SET(OSX_SYSTEM 10.15)
 	ELSEIF(${MAC_SYS} MATCHES 17)
 		SET(OSX_SYSTEM 10.14)
 	ELSEIF(${MAC_SYS} MATCHES 16)
@@ -186,13 +180,9 @@ IF(APPLE)
 
 	SET(CMAKE_XCODE_ATTRIBUTE_ARCHS $(NATIVE_ARCH_ACTUAL))
 
-    IF(AZURE)
-	   SET(CMAKE_OSX_SYSROOT /Applications/Xcode_10.1.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${OSX_SYSTEM}.sdk)
-    ELSE()
-       SET(CMAKE_OSX_SYSROOT /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${OSX_SYSTEM}.sdk)
-    ENDIF()
+  SET(CMAKE_OSX_SYSROOT /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX${OSX_SYSTEM}.sdk)
 
-    SET(CMAKE_XCODE_ATTRIBUTE_SDKROOT macosx) # to silence sdk not found warning, just overrides CMAKE_OSX_SYSROOT, gets latest available
+  SET(CMAKE_XCODE_ATTRIBUTE_SDKROOT macosx) # to silence sdk not found warning, just overrides CMAKE_OSX_SYSROOT, gets latest available
 
 	# set a precedence of sdk path over all other default search pathes
 	SET(CMAKE_FIND_ROOT_PATH ${CMAKE_OSX_SYSROOT})
@@ -226,7 +216,7 @@ IF(APPLE)
 
   SET(CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE} ${OSX_FLAGS_RELEASE}")
   SET(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} ${OSX_FLAGS_RELEASE}")
-  
+
   IF(LUXRAYS_ENABLE_CUDA)
     SET(CMAKE_EXE_LINKER_FLAGS "-F/Library/Frameworks -Xlinker -framework -Xlinker CUDA -Wl,-unexported_symbols_list -Wl,\"${CMAKE_SOURCE_DIR}/cmake/exportmaps/unexported_symbols.map\"")
     SET(CMAKE_MODULE_LINKER_FLAGS "-F/Library/Frameworks -Xlinker -framework -Xlinker CUDA -Wl,-unexported_symbols_list -Wl,\"${CMAKE_SOURCE_DIR}/cmake/exportmaps/unexported_symbols.map\"")
@@ -234,7 +224,7 @@ IF(APPLE)
     SET(CMAKE_EXE_LINKER_FLAGS "-Wl,-unexported_symbols_list -Wl,\"${CMAKE_SOURCE_DIR}/cmake/exportmaps/unexported_symbols.map\"")
     SET(CMAKE_MODULE_LINKER_FLAGS "-Wl,-unexported_symbols_list -Wl,\"${CMAKE_SOURCE_DIR}/cmake/exportmaps/unexported_symbols.map\"")
   ENDIF()
-  
+
   SET(CMAKE_XCODE_ATTRIBUTE_DEPLOYMENT_POSTPROCESSING YES) # strip symbols in whole project, disabled in pylux target
   SET(CMAKE_XCODE_ATTRIBUTE_DEAD_CODE_STRIPPING YES)
   SET(CMAKE_XCODE_ATTRIBUTE_LLVM_LTO YES)
@@ -243,7 +233,7 @@ IF(APPLE)
   MESSAGE(STATUS "################ GENERATED XCODE PROJECT INFORMATION ################")
   MESSAGE(STATUS "")
   MESSAGE(STATUS "DETECTED SYSTEM-VERSION: " ${MAC_SYS})
-  MESSAGE(STATUS "DETECTED MacOS-VERSION: " ${OSX_SYSTEM})
+  MESSAGE(STATUS "DETECTED SDK-VERSION: " ${OSX_SYSTEM})
   MESSAGE(STATUS "OSX_DEPLOYMENT_TARGET : " ${CMAKE_OSX_DEPLOYMENT_TARGET})
   MESSAGE(STATUS "CMAKE_XCODE_ATTRIBUTE_ARCHS: " ${CMAKE_XCODE_ATTRIBUTE_ARCHS})
   MESSAGE(STATUS "OSX SDK SETTING : " ${CMAKE_XCODE_ATTRIBUTE_SDKROOT}${OSX_SYSTEM})

--- a/scripts/azurepipeline/macos/build.sh
+++ b/scripts/azurepipeline/macos/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 #Fetch Artifacts
-wget https://github.com/LuxCoreRender/MacOSCompileDeps/releases/download/luxcorerender_v2.4beta2/MacDistFiles.tar.gz
+wget https://github.com/LuxCoreRender/MacOSCompileDeps/releases/download/luxcorerender_v2.4beta3/MacDistFiles.tar.gz
 tar xzf MacDistFiles.tar.gz
 
 # Set Environment Variables

--- a/scripts/azurepipeline/macos/codesign.sh
+++ b/scripts/azurepipeline/macos/codesign.sh
@@ -1,5 +1,5 @@
 _mount_dir="$1"
-_entitlements="./scripts/macos/entitlements.plist"
+_entitlements="./scripts/azurepipeline/macos/entitlements.plist"
 
 echo "Codesigning .dylib and .so libraries"
 for f in $(find "${_mount_dir}" -name "*.dylib" -o -name "*.so"); do

--- a/scripts/azurepipeline/macos/entitlements.plist
+++ b/scripts/azurepipeline/macos/entitlements.plist
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <!-- For Python ctypes to work. -->
+  <key>com.apple.security.cs.allow-unsigned-executable-memory</key>
+  <true/>
+  <!-- For loading unsigned dylib plugins. -->
+  <key>com.apple.security.cs.disable-library-validation</key>
+  <true/>
+  <!-- For LLVM. -->
+  <key>com.apple.security.cs.allow-jit</key>
+  <true/>
+</dict>
+</plist>

--- a/scripts/azurepipeline/macos/install.sh
+++ b/scripts/azurepipeline/macos/install.sh
@@ -1,7 +1,5 @@
 #!/bin/bash
-
-#switch to XCode 10.1
-sudo xcode-select -s /Applications/Xcode_10.1.app
+ 
 #Install Build Tools
 brew install bison
 brew install pyenv

--- a/scripts/azurepipeline/macos/pack.sh
+++ b/scripts/azurepipeline/macos/pack.sh
@@ -11,6 +11,7 @@ mkdir release_OSX
 echo "Bundeling OpenCL less Version"
 
 cp -R macos/mac_bundle/LuxCore.app release_OSX
+mkdir -p release_OSX/LuxCore.app/Contents/MacOS
 cp build/Release/luxcoreui release_OSX/LuxCore.app/Contents/MacOS
 
 cd release_OSX
@@ -26,18 +27,14 @@ install_name_tool -id @executable_path/../Resources/libs/libomp.dylib LuxCore.ap
 #libembree
 
 cp -f $DEPS_SOURCE/lib/libembree3.3.dylib LuxCore.app/Contents/Resources/libs/libembree3.3.dylib
-#chmod +w LuxCore.app/Contents/Resources/libs/libembree3.3.dylib
-#install_name_tool -id @executable_path/../Resources/libs/libembree3.3.dylib LuxCore.app/Contents/Resources/libs/libembree3.3.dylib
-#install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs/libtbb.dylib LuxCore.app/Contents/Resources/libs/libembree3.3.dylib
-#install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/Resources/libs/libembree3.3.dylib
 
 #libOpenImageDenoise
 
-cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-chmod +w LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -id @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs/libtbb.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
+cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+chmod +w LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -id @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs/libtbb.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
 
 #libtbb
 
@@ -72,7 +69,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib LuxCore.app/Contents/MacOS/luxcoreui
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
 
 echo "LuxCoreUi installed"
 
@@ -88,7 +85,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 
 echo "LuxCoreConsole installed"
 
@@ -107,13 +104,9 @@ cp -f $DEPS_SOURCE/lib/libomp.dylib ./libomp.dylib
 chmod +w ./libomp.dylib
 install_name_tool -id @loader_path/libomp.dylib ./libomp.dylib
 
-#libembree 
+#libembree
 
 cp -f $DEPS_SOURCE/lib/libembree3.3.dylib ./libembree3.3.dylib
-#chmod +w ./libembree3.3.dylib
-#install_name_tool -id @loader_path/libembree3.3.dylib ./libembree3.3.dylib
-#install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib ./libembree3.3.dylib
-#install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ./libembree3.3.dylib
 
 #libtbb
 
@@ -142,11 +135,11 @@ install_name_tool -id @loader_path/libtbbmalloc.dylib ./libtbbmalloc.dylib
 
 #libOpenImageDenoise
 
-cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.1.0.dylib ./libOpenImageDenoise.1.1.0.dylib
-chmod +w ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -id @loader_path/libOpenImageDenoise.1.1.0.dylib ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ./libOpenImageDenoise.1.1.0.dylib
+cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.2.0.dylib ./libOpenImageDenoise.1.2.0.dylib
+chmod +w ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -id @loader_path/libOpenImageDenoise.1.2.0.dylib ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ./libOpenImageDenoise.1.2.0.dylib
 
 #pyluxcore.so
 
@@ -156,7 +149,7 @@ install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib pyluxcor
 install_name_tool -change @rpath/libtiff.5.dylib @loader_path/libtiff.5.dylib pyluxcore.so
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @loader_path/libOpenImageIO.1.8.dylib pyluxcore.so
 install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib pyluxcore.so
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.1.0.dylib pyluxcore.so
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.2.0.dylib pyluxcore.so
 
 echo "PyLuxCore installed"
 
@@ -166,8 +159,8 @@ echo "PyLuxCore installed"
 cp ../../macos/bin/denoise .
 chmod +w ./denoise
 install_name_tool -id @executable_path/denoise ./denoise
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/libOpenImageDenoise.1.1.0.dylib denoise
-install_name_tool -change @rpath/libOpenImageDenoise.1.1.0.dylib @executable_path/libOpenImageDenoise.1.1.0.dylib denoise
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/libOpenImageDenoise.1.2.0.dylib denoise
+install_name_tool -change @rpath/libOpenImageDenoise.1.2.0.dylib @executable_path/libOpenImageDenoise.1.2.0.dylib denoise
 install_name_tool -change @rpath/libtbb.dylib @executable_path/libtbb.dylib denoise
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/libtbbmalloc.dylib denoise
 
@@ -231,7 +224,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib LuxCore.app/Contents/MacOS/luxcoreui
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
 
 echo "LuxCoreUi installed"
 
@@ -243,7 +236,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 
 echo "LuxCoreConsole installed"
 
@@ -257,7 +250,7 @@ install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib pyluxcor
 install_name_tool -change @rpath/libtiff.5.dylib @loader_path/libtiff.5.dylib pyluxcore.so
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @loader_path/libOpenImageIO.1.8.dylib pyluxcore.so
 install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib pyluxcore.so
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.1.0.dylib pyluxcore.so
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.2.0.dylib pyluxcore.so
 
 echo "PyLuxCore installed"
 
@@ -269,7 +262,7 @@ cd ..
 
 ### creating opencl DMG
 
-#for fancy background 
+#for fancy background
 
 #create-dmg --volname "LuxCoreRender$VERSION_STRING-opencl" --background macos/mac_bundle/back-dmg.jpg --window-size 512 300 --app-drop-link 60 175 --icon-size 64 --text-size 12 --icon LuxCore.app 0 65 --icon luxcoreconsole 120 65 --icon pyluxcore 250 65  --volicon macos/mac_bundle/LuxCore.app/Contents/Resources/luxcoreui.icns luxcorerender-$VERSION_STRING-mac64$SDK_BUILD-opencl.dmg release_OSX_ocl/
 
@@ -282,20 +275,3 @@ echo "Staging OpenCL Version DMG"
 mv luxcorerender-$VERSION_STRING-mac64$SDK_BUILD-opencl.dmg $BUILD_ARTIFACTSTAGINGDIRECTORY/luxcorerender-$VERSION_STRING-mac64$SDK_BUILD-opencl.dmg
 
 echo "Finished ! All is good !"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/scripts/azurepipeline/macos/pack.sh
+++ b/scripts/azurepipeline/macos/pack.sh
@@ -166,7 +166,9 @@ install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/libtbbmallo
 
 echo "Denoise installed"
 
-cd ../..
+cd
+
+./scripts/azurepipeline/macos/codesign.sh /release_OSX/pyluxcore
 
 # Set up correct names for release version and SDK
 if [[ -z "$VERSION_STRING" ]] ; then
@@ -259,6 +261,8 @@ cd ..
 echo "Denoise installed"
 
 cd ..
+
+./scripts/azurepipeline/macos/codesign.sh /release_OSX_ocl/pyluxcore
 
 ### creating opencl DMG
 

--- a/scripts/macos/codesign.sh
+++ b/scripts/macos/codesign.sh
@@ -4,5 +4,5 @@ _entitlements="./scripts/macos/entitlements.plist"
 echo ; echo "Codesigning .dylib and .so libraries"
 for f in $(find "${_mount_dir}" -name "*.dylib" -o -name "*.so"); do
    codesign --remove-signature "${f}"
-   codesign --timestamp --options runtime --entitlements="${_entitlements}" --sign "E3C3F1D135EB71C95141E9D3265DF35A6065C7A0" "${f}"
+   codesign --timestamp --options runtime --entitlements="${_entitlements}" --sign "24293BCE17D91BE0078BE5616A602479703843BA" "${f}"
 done

--- a/scripts/macos/doit.sh
+++ b/scripts/macos/doit.sh
@@ -28,7 +28,8 @@ mkdir release_OSX
 echo "Bundeling OpenCL Version"
 
 cp -R macos/mac_bundle/LuxCore.app release_OSX
-cp build/Release/luxcoreui release_OSX/LuxCore.app/Contents/MacOS
+mkdir -p release_OSX/LuxCore.app/Contents/MacOS/
+cp build/Release/luxcoreui release_OSX/LuxCore.app/Contents/MacOS/luxcoreui
 
 cd release_OSX
 
@@ -91,7 +92,7 @@ echo "LuxCoreUi installed"
 
 ###luxcoreconsole
 
-cp ../build/Release/luxcoreconsole LuxCore.app/Contents/MacOS
+cp ../build/Release/luxcoreconsole LuxCore.app/Contents/MacOS/luxcoreconsole
 
 #luxcoreconsole
 
@@ -109,8 +110,8 @@ echo "LuxCoreConsole installed"
 
 mkdir pyluxcore
 
-cp ../build/lib/Release/pyluxcore.so pyluxcore
-cp ../build/lib/pyluxcoretools.zip pyluxcore
+cp ../build/lib/Release/pyluxcore.so ./pyluxcore/pyluxcore.so
+cp ../build/lib/pyluxcoretools.zip ./pyluxcore/pyluxcoretools.zip
 
 cd pyluxcore
 
@@ -120,7 +121,7 @@ cp -f $DEPS_SOURCE/lib/libomp.dylib ./libomp.dylib
 chmod +w ./libomp.dylib
 install_name_tool -id @loader_path/libomp.dylib ./libomp.dylib
 
-#libembree 
+#libembree
 
 cp -f $DEPS_SOURCE/lib/libembree3.3.dylib ./libembree3.3.dylib
 

--- a/scripts/macos/doit.sh
+++ b/scripts/macos/doit.sh
@@ -185,7 +185,7 @@ echo "Denoise installed"
 
 cd ../..
 
-./scripts/macos/codesign.sh
+./scripts/macos/codesign.sh ./release_OSX/pyluxcore
 
 # Set up correct names for release version and SDK
 if [[ -z "$VERSION_STRING" ]] ; then

--- a/scripts/macos/doit.sh
+++ b/scripts/macos/doit.sh
@@ -46,11 +46,11 @@ cp -f $DEPS_SOURCE/lib/libembree3.3.dylib LuxCore.app/Contents/Resources/libs/li
 
 #libOpenImageDenoise
 
-cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-chmod +w LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -id @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs/libtbb.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
+cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+chmod +w LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -id @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs/libtbb.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
 
 #libtbb
 
@@ -85,7 +85,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib LuxCore.app/Contents/MacOS/luxcoreui
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
 
 echo "LuxCoreUi installed"
 
@@ -101,7 +101,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 
 echo "LuxCoreConsole installed"
 
@@ -151,11 +151,11 @@ install_name_tool -id @loader_path/libtbbmalloc.dylib ./libtbbmalloc.dylib
 
 #libOpenImageDenoise
 
-cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.1.0.dylib ./libOpenImageDenoise.1.1.0.dylib
-chmod +w ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -id @loader_path/libOpenImageDenoise.1.1.0.dylib ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ./libOpenImageDenoise.1.1.0.dylib
+cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.2.0.dylib ./libOpenImageDenoise.1.2.0.dylib
+chmod +w ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -id @loader_path/libOpenImageDenoise.1.2.0.dylib ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ./libOpenImageDenoise.1.2.0.dylib
 
 #pyluxcore.so
 
@@ -165,7 +165,7 @@ install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib pyluxcor
 install_name_tool -change @rpath/libtiff.5.dylib @loader_path/libtiff.5.dylib pyluxcore.so
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @loader_path/libOpenImageIO.1.8.dylib pyluxcore.so
 install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib pyluxcore.so
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.1.0.dylib pyluxcore.so
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.2.0.dylib pyluxcore.so
 
 echo "PyLuxCore installed"
 
@@ -175,8 +175,8 @@ echo "PyLuxCore installed"
 cp ../../macos/bin/denoise .
 chmod +w ./denoise
 install_name_tool -id @executable_path/denoise ./denoise
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/libOpenImageDenoise.1.1.0.dylib denoise
-install_name_tool -change @rpath/libOpenImageDenoise.1.1.0.dylib @executable_path/libOpenImageDenoise.1.1.0.dylib denoise
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/libOpenImageDenoise.1.2.0.dylib denoise
+install_name_tool -change @rpath/libOpenImageDenoise.1.2.0.dylib @executable_path/libOpenImageDenoise.1.2.0.dylib denoise
 install_name_tool -change @rpath/libtbb.dylib @executable_path/libtbb.dylib denoise
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/libtbbmalloc.dylib denoise
 

--- a/scripts/macos/pack_lux_osx.sh
+++ b/scripts/macos/pack_lux_osx.sh
@@ -29,11 +29,11 @@ cp -f $DEPS_SOURCE/lib/libembree3.3.dylib LuxCore.app/Contents/Resources/libs/li
 
 #libOpenImageDenoise
 
-cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-chmod +w LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -id @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs/libtbb.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
+cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+chmod +w LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -id @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs/libtbb.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
 
 #libtbb
 
@@ -68,7 +68,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib LuxCore.app/Contents/MacOS/luxcoreui
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
 
 echo "LuxCoreUi installed"
 
@@ -84,7 +84,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 
 echo "LuxCoreConsole installed"
 
@@ -134,11 +134,11 @@ install_name_tool -id @loader_path/libtbbmalloc.dylib ./libtbbmalloc.dylib
 
 #libOpenImageDenoise
 
-cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.1.0.dylib ./libOpenImageDenoise.1.1.0.dylib
-chmod +w ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -id @loader_path/libOpenImageDenoise.1.1.0.dylib ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ./libOpenImageDenoise.1.1.0.dylib
+cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.2.0.dylib ./libOpenImageDenoise.1.2.0.dylib
+chmod +w ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -id @loader_path/libOpenImageDenoise.1.2.0.dylib ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ./libOpenImageDenoise.1.2.0.dylib
 
 #pyluxcore.so
 
@@ -148,7 +148,7 @@ install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib pyluxcor
 install_name_tool -change @rpath/libtiff.5.dylib @loader_path/libtiff.5.dylib pyluxcore.so
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @loader_path/libOpenImageIO.1.8.dylib pyluxcore.so
 install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib pyluxcore.so
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.1.0.dylib pyluxcore.so
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.2.0.dylib pyluxcore.so
 
 echo "PyLuxCore installed"
 
@@ -158,8 +158,8 @@ echo "PyLuxCore installed"
 cp ../../macos/bin/denoise .
 chmod +w ./denoise
 install_name_tool -id @executable_path/denoise ./denoise
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/libOpenImageDenoise.1.1.0.dylib denoise
-install_name_tool -change @rpath/libOpenImageDenoise.1.1.0.dylib @executable_path/libOpenImageDenoise.1.1.0.dylib denoise
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/libOpenImageDenoise.1.2.0.dylib denoise
+install_name_tool -change @rpath/libOpenImageDenoise.1.2.0.dylib @executable_path/libOpenImageDenoise.1.2.0.dylib denoise
 install_name_tool -change @rpath/libtbb.dylib @executable_path/libtbb.dylib denoise
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/libtbbmalloc.dylib denoise
 

--- a/scripts/macos/pack_lux_osx.sh
+++ b/scripts/macos/pack_lux_osx.sh
@@ -11,6 +11,7 @@ mkdir release_OSX
 echo "Bundeling OpenCL Version"
 
 cp -R macos/mac_bundle/LuxCore.app release_OSX
+mkdir -p release_OSX/LuxCore.app/Contents/MacOS/
 cp build/Release/luxcoreui release_OSX/LuxCore.app/Contents/MacOS
 
 cd release_OSX
@@ -103,7 +104,7 @@ cp -f $DEPS_SOURCE/lib/libomp.dylib ./libomp.dylib
 chmod +w ./libomp.dylib
 install_name_tool -id @loader_path/libomp.dylib ./libomp.dylib
 
-#libembree 
+#libembree
 
 cp -f $DEPS_SOURCE/lib/libembree3.3.dylib ./libembree3.3.dylib
 
@@ -189,23 +190,3 @@ hdiutil create luxcorerender-$VERSION_STRING-mac64$SDK_BUILD.dmg -volname "LuxCo
 #create-dmg --volname "LuxCoreRender-$VERSION_STRING" --format UDBZ --background macos/mac_bundle/back-dmg.jpg --window-size 512 300 --app-drop-link 320 140 --icon-size 64 --text-size 12 --icon LuxCore.app 105 140 --icon pyluxcore 205 140  --volicon macos/mac_bundle/LuxCore.app/Contents/Resources/luxcoreui.icns luxcorerender-$VERSION_STRING-mac64$SDK_BUILD-opencl.dmg release_OSX/
 
 echo "Done !"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/scripts/macos/pack_lux_osx_xcode.sh
+++ b/scripts/macos/pack_lux_osx_xcode.sh
@@ -11,6 +11,7 @@ mkdir release_OSX
 echo "Bundeling OpenCL Version"
 
 cp -R macos/mac_bundle/LuxCore.app release_OSX
+mkdir -p release_OSX/LuxCore.app/Contents/MacOS/
 cp build/bin/Release/luxcoreui release_OSX/LuxCore.app/Contents/MacOS
 
 cd release_OSX
@@ -107,7 +108,7 @@ cp -f $DEPS_SOURCE/lib/libomp.dylib ./libomp.dylib
 chmod +w ./libomp.dylib
 install_name_tool -id @loader_path/libomp.dylib ./libomp.dylib
 
-#libembree 
+#libembree
 
 cp -f $DEPS_SOURCE/lib/libembree3.3.dylib ./libembree3.3.dylib
 #chmod +w ./libembree3.3.dylib
@@ -197,23 +198,3 @@ hdiutil create luxcorerender-$VERSION_STRING-mac64$SDK_BUILD.dmg -volname "LuxCo
 #create-dmg --volname "LuxCoreRender-$VERSION_STRING" --format UDBZ --background macos/mac_bundle/back-dmg.jpg --window-size 512 300 --app-drop-link 320 140 --icon-size 64 --text-size 12 --icon LuxCore.app 105 140 --icon pyluxcore 205 140  --volicon macos/mac_bundle/LuxCore.app/Contents/Resources/luxcoreui.icns luxcorerender-$VERSION_STRING-mac64$SDK_BUILD-opencl.dmg release_OSX/
 
 echo "Done !"
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-

--- a/scripts/macos/pack_lux_osx_xcode.sh
+++ b/scripts/macos/pack_lux_osx_xcode.sh
@@ -33,11 +33,11 @@ cp -f $DEPS_SOURCE/lib/libembree3.3.dylib LuxCore.app/Contents/Resources/libs/li
 
 #libOpenImageDenoise
 
-cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-chmod +w LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -id @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs/libtbb.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.1.0.dylib
+cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+chmod +w LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -id @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs/libtbb.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/Resources/libs/libOpenImageDenoise.1.2.0.dylib
 
 #libtbb
 
@@ -72,7 +72,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib LuxCore.app/Contents/MacOS/luxcoreui
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib LuxCore.app/Contents/MacOS/luxcoreui
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib LuxCore.app/Contents/MacOS/luxcoreui
 
 echo "LuxCoreUi installed"
 
@@ -88,7 +88,7 @@ install_name_tool -change @rpath/libtbb.dylib @executable_path/../Resources/libs
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @executable_path/../Resources/libs/libOpenImageIO.1.8.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/../Resources/libs/libtbbmalloc.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 install_name_tool -change @rpath/libtiff.5.dylib @executable_path/../Resources/libs/libtiff.5.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.1.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/../Resources/libs/libOpenImageDenoise.1.2.0.dylib ./LuxCore.app/Contents/MacOS/luxcoreconsole
 
 echo "LuxCoreConsole installed"
 
@@ -142,11 +142,11 @@ install_name_tool -id @loader_path/libtbbmalloc.dylib ./libtbbmalloc.dylib
 
 #libOpenImageDenoise
 
-cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.1.0.dylib ./libOpenImageDenoise.1.1.0.dylib
-chmod +w ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -id @loader_path/libOpenImageDenoise.1.1.0.dylib ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib ./libOpenImageDenoise.1.1.0.dylib
-install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ./libOpenImageDenoise.1.1.0.dylib
+cp -f $DEPS_SOURCE/lib/libOpenImageDenoise.1.2.0.dylib ./libOpenImageDenoise.1.2.0.dylib
+chmod +w ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -id @loader_path/libOpenImageDenoise.1.2.0.dylib ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib ./libOpenImageDenoise.1.2.0.dylib
+install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib ./libOpenImageDenoise.1.2.0.dylib
 
 #pyluxcore.so
 
@@ -156,7 +156,7 @@ install_name_tool -change @rpath/libtbb.dylib @loader_path/libtbb.dylib pyluxcor
 install_name_tool -change @rpath/libtiff.5.dylib @loader_path/libtiff.5.dylib pyluxcore.so
 install_name_tool -change @rpath/libOpenImageIO.1.8.dylib @loader_path/libOpenImageIO.1.8.dylib pyluxcore.so
 install_name_tool -change @rpath/libtbbmalloc.dylib @loader_path/libtbbmalloc.dylib pyluxcore.so
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.1.0.dylib pyluxcore.so
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @loader_path/libOpenImagedenoise.1.2.0.dylib pyluxcore.so
 
 echo "PyLuxCore installed"
 
@@ -166,8 +166,8 @@ echo "PyLuxCore installed"
 cp ../../macos/bin/denoise .
 chmod +w ./denoise
 install_name_tool -id @executable_path/denoise ./denoise
-install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/libOpenImageDenoise.1.1.0.dylib denoise
-install_name_tool -change @rpath/libOpenImageDenoise.1.1.0.dylib @executable_path/libOpenImageDenoise.1.1.0.dylib denoise
+install_name_tool -change @rpath/libOpenImageDenoise.0.dylib @executable_path/libOpenImageDenoise.1.2.0.dylib denoise
+install_name_tool -change @rpath/libOpenImageDenoise.1.2.0.dylib @executable_path/libOpenImageDenoise.1.2.0.dylib denoise
 install_name_tool -change @rpath/libtbb.dylib @executable_path/libtbb.dylib denoise
 install_name_tool -change @rpath/libtbbmalloc.dylib @executable_path/libtbbmalloc.dylib denoise
 


### PR DESCRIPTION
Azure will now compile with Xcode 11.2 due to permission problems with Xcode 10 concerning code signing.

changes for OIDN 1.2 and updated MacOsDistFiles link.