### PR TITLE
Adding processor group support for more than 64 logical processors

### DIFF
--- a/src/slg/engines/cpurenderengine.cpp
+++ b/src/slg/engines/cpurenderengine.cpp
@@ -20,6 +20,10 @@
 
 #include "slg/engines/cpurenderengine.h"
 
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64)
+#include <Windows.h>
+#endif
+
 using namespace std;
 using namespace luxrays;
 using namespace slg;
@@ -186,7 +190,13 @@ Properties CPURenderEngine::ToProperties(const Properties &cfg) {
 const Properties &CPURenderEngine::GetDefaultProps() {
 	static Properties props = Properties() <<
 			RenderEngine::GetDefaultProps() <<
+//For Windows version greater than Windows 7,modern way of calculating processor count is used 
+//May not work with Windows version prior to Windows 7
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64)
+			Property("native.threads.count")((int)GetActiveProcessorCount(ALL_PROCESSOR_GROUPS));
+#else 
 			Property("native.threads.count")(boost::thread::hardware_concurrency());
+#endif
 
 	return props;
 }

--- a/src/slg/engines/oclrenderengine.cpp
+++ b/src/slg/engines/oclrenderengine.cpp
@@ -23,6 +23,10 @@
 #include "luxrays/devices/ocldevice.h"
 #endif
 
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64)
+#include <Windows.h>
+#endif
+
 using namespace std;
 using namespace luxrays;
 using namespace slg;
@@ -133,7 +137,13 @@ const Properties &OCLRenderEngine::GetDefaultProps() {
 #endif
 			Property("opencl.gpu.workgroup.size")(32) <<
 			Property("opencl.devices.select")("") <<
+//For Windows version greater than Windows 7,modern way of calculating processor count is used 
+//May not work with Windows version prior to Windows 7
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64)
+			Property("opencl.native.threads.count")((int)GetActiveProcessorCount(ALL_PROCESSOR_GROUPS));
+#else
 			Property("opencl.native.threads.count")(boost::thread::hardware_concurrency());
+#endif
 
 	return props;
 }

--- a/src/slg/engines/pathcpu/pathcputhread.cpp
+++ b/src/slg/engines/pathcpu/pathcputhread.cpp
@@ -21,6 +21,10 @@
 #include "slg/utils/varianceclamping.h"
 #include "slg/samplers/metropolis.h"
 
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64)
+#include <Windows.h>
+#endif
+
 using namespace std;
 using namespace luxrays;
 using namespace slg;
@@ -43,6 +47,25 @@ void PathCPURenderThread::RenderFunc() {
 
 	PathCPURenderEngine *engine = (PathCPURenderEngine *)renderEngine;
 	const PathTracer &pathTracer = engine->pathTracer;
+
+//Set thread affinity the modern way.May not work for Windows version prior to Windows7
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined (WIN64)
+	auto totalProcessors = 0U;
+	int processorIndex = threadIndex % GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+
+	// Determine which processor group to bind the thread to.
+	for (auto i = 0U; i < GetActiveProcessorGroupCount(); ++i)
+	{
+		totalProcessors += GetActiveProcessorCount(i);
+		if (totalProcessors >= processorIndex)
+		{
+			auto mask = (1ULL << GetActiveProcessorCount(i)) - 1;
+			GROUP_AFFINITY groupAffinity = { mask, static_cast<WORD>(i), { 0, 0, 0 } };
+			SetThreadGroupAffinity(GetCurrentThread(), &groupAffinity, nullptr);
+			break;
+		}
+	}
+#endif
 	// (engine->seedBase + 1) seed is used for sharedRndGen
 	RandomGenerator *rndGen = new RandomGenerator(engine->seedBase + 1 + threadIndex);
 

--- a/src/slg/engines/pathocl/pathoclnativethread.cpp
+++ b/src/slg/engines/pathocl/pathoclnativethread.cpp
@@ -31,6 +31,10 @@
 #include "slg/renderconfig.h"
 #include "slg/engines/pathocl/pathocl.h"
 
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64)
+#include <Windows.h>
+#endif
+
 using namespace std;
 using namespace luxrays;
 using namespace slg;
@@ -90,6 +94,25 @@ void PathOCLNativeRenderThread::RenderThreadImpl() {
 
 	PathOCLRenderEngine *engine = (PathOCLRenderEngine *)renderEngine;
 	const PathTracer &pathTracer = engine->pathTracer;
+
+//Set thread affinity the modern way.May not work for Windows version prior to Windows7
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64)	
+	auto totalProcessors = 0U;
+	int processorIndex = threadIndex % GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+
+	// Determine which processor group to bind the thread to.
+	for (auto i = 0U; i < GetActiveProcessorGroupCount(); ++i)
+	{
+		totalProcessors += GetActiveProcessorCount(i);
+		if (totalProcessors >= processorIndex)
+		{
+			auto mask = (1ULL << GetActiveProcessorCount(i)) - 1;
+			GROUP_AFFINITY groupAffinity = { mask, static_cast<WORD>(i), { 0, 0, 0 } };
+			SetThreadGroupAffinity(GetCurrentThread(), &groupAffinity, nullptr);
+			break;
+		}
+	}
+#endif
 	// (engine->seedBase + 1) seed is used for sharedRndGen
 	RandomGenerator *rndGen = new RandomGenerator(engine->seedBase + 1 + threadIndex);
 


### PR DESCRIPTION
Adding processor group support to enable LuxCoreRender to use more than 64 logical processors.This will work on Windows 7 and above.