### PR TITLE
Update bidirectional render function with thread affinity snippet

### DIFF
--- a/src/slg/engines/bidircpu/bidircputhread.cpp
+++ b/src/slg/engines/bidircpu/bidircputhread.cpp
@@ -528,6 +528,25 @@ void BiDirCPURenderThread::RenderFunc() {
 
 	BiDirCPURenderEngine *engine = (BiDirCPURenderEngine *)renderEngine;
 	// (engine->seedBase + 1) seed is used for sharedRndGen
+
+	//Set thread affinity the modern way.May not work for Windows version prior to Windows7
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined (WIN64)
+	auto totalProcessors = 0U;
+	int processorIndex = threadIndex % GetActiveProcessorCount(ALL_PROCESSOR_GROUPS);
+
+	// Determine which processor group to bind the thread to.
+	for (auto i = 0U; i < GetActiveProcessorGroupCount(); ++i)
+	{
+		totalProcessors += GetActiveProcessorCount(i);
+		if (totalProcessors >= processorIndex)
+		{
+			auto mask = (1ULL << GetActiveProcessorCount(i)) - 1;
+			GROUP_AFFINITY groupAffinity = { mask, static_cast<WORD>(i), { 0, 0, 0 } };
+			SetThreadGroupAffinity(GetCurrentThread(), &groupAffinity, nullptr);
+			break;
+		}
+	}
+#endif
 	RandomGenerator *rndGen = new RandomGenerator(engine->seedBase + 1 + threadIndex);
 	Scene *scene = engine->renderConfig->scene;
 	Camera *camera = scene->camera;


### PR DESCRIPTION
Updated bidirectional render engine which will correct the thread-to-core mapping for processors with more than 64 hardware threads (used the same thread affinity module used in PathCPURender). All the available threads will be utilized while rendering the scene using Bidirectional CPU render engine. 