### PR TITLE
Change Cauchy naming convention in glass material

### DIFF
--- a/include/slg/materials/glass.h
+++ b/include/slg/materials/glass.h
@@ -33,7 +33,7 @@ public:
 			const Texture *emitted, const Texture *bump,
 			const Texture *refl, const Texture *trans,
 			const Texture *exteriorIorFact, const Texture *interiorIorFact,
-			const Texture *C, 
+			const Texture *B, 
 			const Texture *filmThickness, const Texture *filmIor);
 
 	virtual MaterialType GetType() const { return GLASS; }
@@ -61,7 +61,7 @@ public:
 	const Texture *GetKt() const { return Kt; }
 	const Texture *GetExteriorIOR() const { return exteriorIor; }
 	const Texture *GetInteriorIOR() const { return interiorIor; }
-	const Texture *GetCauchyC() const { return cauchyC; }
+	const Texture *GetCauchyB() const { return cauchyB; }
 	const Texture *GetFilmThickness() const { return filmThickness; }
 	const Texture *GetFilmIOR() const { return filmIor; }
 
@@ -73,7 +73,7 @@ public:
 	static luxrays::Spectrum EvalSpecularTransmission(const HitPoint &hitPoint,
 			const luxrays::Vector &localFixedDir, const float u0,
 			const luxrays::Spectrum &kt,
-			const float nc, const float nt, const float cauchyC,
+			const float nc, const float nt, const float cauchyB,
 			luxrays::Vector *localSampledDir);
 
 private:
@@ -82,7 +82,7 @@ private:
 	const Texture *Kt;
 	const Texture *exteriorIor;
 	const Texture *interiorIor;
-	const Texture *cauchyC;
+	const Texture *cauchyB;
 	const Texture *filmThickness;
 	const Texture *filmIor;
 };

--- a/include/slg/materials/material_types.cl
+++ b/include/slg/materials/material_types.cl
@@ -92,7 +92,7 @@ typedef struct {
     unsigned int krTexIndex;
 	unsigned int ktTexIndex;
 	unsigned int exteriorIorTexIndex, interiorIorTexIndex;
-	unsigned int cauchyCTex;
+	unsigned int cauchyBTex;
 	unsigned int filmThicknessTexIndex;
 	unsigned int filmIorTexIndex;
 } GlassParam;

--- a/include/slg/materials/materialdefs_funcs_glass.cl
+++ b/include/slg/materials/materialdefs_funcs_glass.cl
@@ -109,11 +109,14 @@ OPENCL_FORCE_INLINE float GlassMaterial_WaveLength2IOR(const float waveLength, c
 	// Cauchy's equation for relationship between the refractive index and wavelength
 	// note: Cauchy's lambda is expressed in micrometers while waveLength is in nanometers
 
-	// This is the formula suggested by Neo here:
+	// This is the formula suggested by Neo here, with a changed naming convention from B->A and C-> B:
 	// https://github.com/LuxCoreRender/BlendLuxCore/commit/d3fed046ab62e18226e410b42a16ca1bccefb530#commitcomment-26617643
-	//const float B = IOR - C / Sqr(589.f / 1000.f);
+	
+	// Compute Cauchy-A assuming the user input IOR at 587.56 nm 
+	// (Fraunhofer d-line, Helium, used in one definition of the Abbe number)
+	//const float A = IOR - B / Sqr(587.56f / 1000.f);
 
-	// The B used by old LuxRender
+	// Use the user input IOR directly as Cauchy-A. Equivalent to the B used by old LuxRender.
 	const float A = IOR;
 
 	// Cauchy's equation

--- a/src/slg/engines/pathoclbase/compilematerials.cpp
+++ b/src/slg/engines/pathoclbase/compilematerials.cpp
@@ -678,10 +678,10 @@ void CompiledScene::CompileMaterials() {
 					mat->glass.interiorIorTexIndex = scene->texDefs.GetTextureIndex(gm->GetInteriorIOR());
 				else
 					mat->glass.interiorIorTexIndex = NULL_INDEX;
-				if (gm->GetCauchyC())
-					mat->glass.cauchyCTex = scene->texDefs.GetTextureIndex(gm->GetCauchyC());
+				if (gm->GetCauchyB())
+					mat->glass.cauchyBTex = scene->texDefs.GetTextureIndex(gm->GetCauchyB());
 				else
-					mat->glass.cauchyCTex = NULL_INDEX;
+					mat->glass.cauchyBTex = NULL_INDEX;
 				if (gm->GetFilmThickness())
 					mat->glass.filmThicknessTexIndex = scene->texDefs.GetTextureIndex(gm->GetFilmThickness());
 				else

--- a/src/slg/materials/glass.cpp
+++ b/src/slg/materials/glass.cpp
@@ -104,12 +104,14 @@ static float WaveLength2IOR(const float waveLength, const float IOR, const float
 	// Cauchy's equation for relationship between the refractive index and wavelength
 	// note: Cauchy's lambda is expressed in micrometers while waveLength is in nanometers
 
-	// This is the formula suggested by Neo here:
+	// This is the formula suggested by Neo here, with a changed naming convention from B->A and C-> B:
 	// https://github.com/LuxCoreRender/BlendLuxCore/commit/d3fed046ab62e18226e410b42a16ca1bccefb530#commitcomment-26617643
-	// Compute IOR at 589 nm (natrium D line)
-	//const float B = IOR - C / Sqr(589.f / 1000.f);
+	
+	// Compute Cauchy-A assuming the user input IOR at 587.56 nm 
+	// (Fraunhofer d-line, Helium, used in one definition of the Abbe number)
+	//const float A = IOR - B / Sqr(587.56f / 1000.f);
 
-	// The B used by old LuxRender
+	// Use the user input IOR directly as Cauchy-A. Equivalent to the B used by old LuxRender.
 	const float A = IOR;
 
 	// Cauchy's equation

--- a/src/slg/scene/parsematerials.cpp
+++ b/src/slg/scene/parsematerials.cpp
@@ -212,9 +212,12 @@ Material *Scene::CreateMaterial(const u_int defaultMatID, const string &matName,
 		} else if (props.IsDefined(propName + ".interiorior"))
 			interiorIor = GetTexture(props.Get(Property(propName + ".interiorior")(1.5f)));
 
-		const Texture *cauchyC = NULL;
-		if (props.IsDefined(propName + ".cauchyc"))
-			cauchyC = GetTexture(props.Get(Property(propName + ".cauchyc")(0.f, 0.f, 0.f)));
+		const Texture *cauchyB = NULL;
+		if (props.IsDefined(propName + ".cauchyb"))
+			cauchyB = GetTexture(props.Get(Property(propName + ".cauchyb")(0.f, 0.f, 0.f)));
+		// For compatibility with the past
+		else if (props.IsDefined(propName + ".cauchyc"))
+			cauchyB = GetTexture(props.Get(Property(propName + ".cauchyc")(0.f, 0.f, 0.f)));
 		
 		const Texture *filmThickness = NULL;
 		if (props.IsDefined(propName + ".filmthickness"))
@@ -224,7 +227,7 @@ Material *Scene::CreateMaterial(const u_int defaultMatID, const string &matName,
 		if (props.IsDefined(propName + ".filmior"))
 			filmIor = GetTexture(props.Get(Property(propName + ".filmior")(1.5f)));
 
-		mat = new GlassMaterial(frontTransparencyTex, backTransparencyTex, emissionTex, bumpTex, kr, kt, exteriorIor, interiorIor, cauchyC, filmThickness, filmIor);
+		mat = new GlassMaterial(frontTransparencyTex, backTransparencyTex, emissionTex, bumpTex, kr, kt, exteriorIor, interiorIor, cauchyB, filmThickness, filmIor);
 	} else if (matType == "archglass") {
 		const Texture *kr = GetTexture(props.Get(Property(propName + ".kr")(1.f, 1.f, 1.f)));
 		const Texture *kt = GetTexture(props.Get(Property(propName + ".kt")(1.f, 1.f, 1.f)));

--- a/src/slg/scene/parsematerials.cpp
+++ b/src/slg/scene/parsematerials.cpp
@@ -216,9 +216,10 @@ Material *Scene::CreateMaterial(const u_int defaultMatID, const string &matName,
 		if (props.IsDefined(propName + ".cauchyb"))
 			cauchyB = GetTexture(props.Get(Property(propName + ".cauchyb")(0.f, 0.f, 0.f)));
 		// For compatibility with the past
-		else if (props.IsDefined(propName + ".cauchyc"))
+		else if (props.IsDefined(propName + ".cauchyc")){
 			SLG_LOG("WARNING: deprecated property " + propName + ".cauchyc");
 			cauchyB = GetTexture(props.Get(Property(propName + ".cauchyc")(0.f, 0.f, 0.f)));
+		}
 		
 		const Texture *filmThickness = NULL;
 		if (props.IsDefined(propName + ".filmthickness"))

--- a/src/slg/scene/parsematerials.cpp
+++ b/src/slg/scene/parsematerials.cpp
@@ -217,6 +217,7 @@ Material *Scene::CreateMaterial(const u_int defaultMatID, const string &matName,
 			cauchyB = GetTexture(props.Get(Property(propName + ".cauchyb")(0.f, 0.f, 0.f)));
 		// For compatibility with the past
 		else if (props.IsDefined(propName + ".cauchyc"))
+			SLG_LOG("WARNING: deprecated property " + propName + ".cauchyc");
 			cauchyB = GetTexture(props.Get(Property(propName + ".cauchyc")(0.f, 0.f, 0.f)));
 		
 		const Texture *filmThickness = NULL;


### PR DESCRIPTION
This changes the naming convention of the Cauchy-coefficient of the glass material: Cauchy-C becomes Cauchy-B (with Cauchy-A = IOR).

The original code followed an, apparently uncommon, definition on the corresponding (english) wikipedia page, which has since been changed.

The FresnelCauchyTex also already uses this convention.

Backward compatibility should be ensured through parsematerials.cpp. (Hence I did not -yet- update the included scene files.)

A corresponding update will be submitted for BlendLuxCore.