### PR TITLE
Fix build against Oidn:1.2.4

### DIFF
--- a/cmake/Packages/FindOidn.cmake
+++ b/cmake/Packages/FindOidn.cmake
@@ -14,10 +14,10 @@
 ## limitations under the License.                                           ##
 ## ======================================================================== ##
 
-FIND_PATH(OIDN_INCLUDE_PATH NAMES OpenImageDenoise/version.h PATHS
+FIND_PATH(OIDN_INCLUDE_PATH NAMES OpenImageDenoise/version.h OpenImageDenoise/config.h PATHS
 	${OIDN_ROOT}/include)
 IF (NOT OIDN_INCLUDE_PATH)
-	FIND_PATH(OIDN_INCLUDE_PATH NAMES OpenImageDenoise/version.h PATHS
+	FIND_PATH(OIDN_INCLUDE_PATH NAMES OpenImageDenoise/version.h OpenImageDenoise/config.h PATHS
 		/usr/include
 		/usr/local/include
 		/opt/local/include)


### PR DESCRIPTION
Since Oidn:1.2.4 `version.h` was renamed to `config.h`
https://github.com/OpenImageDenoise/oidn/commit/a0a5cbe9c644b4bda8fae88211b065f72a68eef6