### PR TITLE
Specify target architecture for PTX compilation, based on GPU capability

### DIFF
--- a/release-notes.txt
+++ b/release-notes.txt
@@ -68,6 +68,7 @@ Beta1 released
 * Fixed a discrepancy in reflected area lights on glossy surfaces between CPU and GPU rendering when light tracing is enabled (issue #470)
 * Avoid to return CUDA_ERROR_NO_DEVICE error if CUDA is installed but there are no NVIDIA GPUs installed
 * Fixed compilation when CUDA is disabled but OpenCL is still enabled
+* Now disabling CUDA for any error during the cuInit() like when an external GPU is unplugged (issue #493)
 
 Check https://wiki.luxcorerender.org/LuxCoreRender_Release_Notes for the full list
 of release notes.

--- a/src/luxrays/core/init.cpp
+++ b/src/luxrays/core/init.cpp
@@ -59,17 +59,21 @@ void Init() {
 #endif
 
 #if !defined(LUXRAYS_DISABLE_CUDA)
-	if (cuewInit(CUEW_INIT_CUDA|CUEW_INIT_NVRTC) == CUEW_SUCCESS) {
+	if (cuewInit(CUEW_INIT_CUDA | CUEW_INIT_NVRTC) == CUEW_SUCCESS) {
 		// Was:
 		//CHECK_CUDA_ERROR(cuInit(0));
 
 		const CUresult err = cuInit(0);
-		if (err == CUDA_ERROR_NO_DEVICE) {
-			// This handles the case when CUDA is installed but there are no
-			// NVIDIA GPUs installed.
+		if (err != CUDA_SUCCESS) {
+			// Handling multiple cases like:
+			//
+			// - when CUDA is installed but there are no NVIDIA GPUs available (CUDA_ERROR_NO_DEVICE)
+			//
+			// - when CUDA is installed but there an external GPU is unplugged (CUDA_ERROR_UNKNOWN)
+			//
+			// In all above cases, I just disable CUDA (but with this solution, at
+			/// the moment I have no way to report the type of error).
 		} else {
-			CHECK_CUDA_ERROR(err);
-
 			isCudaAvilable = true;
 
 			// Try to initialize Optix too

--- a/src/luxrays/utils/cuda.cpp
+++ b/src/luxrays/utils/cuda.cpp
@@ -51,6 +51,15 @@ bool cudaKernelCache::ForcedCompilePTX(const vector<string> &kernelsParameters, 
 	vector<const char *> cudaOpts;
 	cudaOpts.push_back("--device-as-default-execution-space");
 	//cudaOpts.push_back("--disable-warnings");
+       
+        // Set target architecture, based on current device's capability
+        CUdevice device;
+        CHECK_CUDA_ERROR(cuCtxGetDevice(&device));
+        int major, minor;
+        CHECK_CUDA_ERROR(cuDeviceGetAttribute(&major, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device));
+        CHECK_CUDA_ERROR(cuDeviceGetAttribute(&minor, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device));
+        string targetArch = "--gpu-architecture=compute_" + major + minor;
+        cudaOpts.push_back(targetArch.c_str());
 
 	// To display warning numbers
 	cudaOpts.push_back("-Xcudafe");


### PR DESCRIPTION
Without this, NVRTC compiler falls back to default 'compute_52' architecture and, in case of GPUs with lower capabilities (<=5.0), it results in a 'CUDA_ERROR_INVALID_PTX' error when loading module.
(while it may also underutilize GPUs with greater capabilities...).