### PR TITLE
Fix missing OpenImageIO error message if film output buffer write fails

### DIFF
--- a/src/slg/film/filmoutput.cpp
+++ b/src/slg/film/filmoutput.cpp
@@ -837,13 +837,13 @@ void Film::Output(const string &fileName,const FilmOutputs::FilmOutputType type,
 
 		if (!buffer.write(safeSave.GetSaveFileName()))
 			throw runtime_error("Error while writing an output type in Film::Output(): " +
-					safeSave.GetSaveFileName() + " (error = " + geterror() + ")");
+					safeSave.GetSaveFileName() + " (error = " + buffer.geterror() + ")");
 
 		safeSave.Process();
 	} else {
 		if (!buffer.write(fileName))
 			throw runtime_error("Error while writing an output type in Film::Output(): " +
-					fileName + " (error = " + geterror() + ")");
+					fileName + " (error = " + buffer.geterror() + ")");
 	}
 }
 


### PR DESCRIPTION
To retrieve the actual error message for OpenImageIO when the buffer write fails, you have to use the `geterror` method of the buffer object. Using the global `geterror` function is for special cases only and returns an empty string when used in this case.