### PR TITLE
Fixes to glossy2 material

### DIFF
--- a/include/slg/materials/materialdefs_funcs_generic.cl
+++ b/include/slg/materials/materialdefs_funcs_generic.cl
@@ -160,6 +160,7 @@ OPENCL_FORCE_INLINE float SchlickDistribution_G(const float roughness, const flo
 }
 
 OPENCL_FORCE_INLINE float GetPhi(const float a, const float b) {
+	if ((a < DEFAULT_EPSILON_MIN) || (b < DEFAULT_EPSILON_MIN)) return 0.f;
 	return M_PI_F * .5f * sqrt(a * b / (1.f - a * (1.f - b)));
 }
 
@@ -254,13 +255,13 @@ OPENCL_FORCE_INLINE float3 SchlickBSDF_CoatingSampleF(const float3 ks,
 	const float cosWH = dot(fixedDir, wh);
 	*sampledDir = 2.f * cosWH * wh - fixedDir;
 
-	if ((fabs((*sampledDir).z) < DEFAULT_COS_EPSILON_STATIC) || (fixedDir.z * (*sampledDir).z < 0.f))
+	if ((fabs((*sampledDir).z) < DEFAULT_COS_EPSILON_STATIC))
 		return BLACK;
 
 	const float coso = fabs(fixedDir.z);
 	const float cosi = fabs((*sampledDir).z);
 
-	*pdf = specPdf / (4.f * cosWH);
+	*pdf = specPdf / (4.f * fabs (cosWH));
 	if (*pdf <= 0.f)
 		return BLACK;
 

--- a/include/slg/materials/materialdefs_funcs_glossy2.cl
+++ b/include/slg/materials/materialdefs_funcs_glossy2.cl
@@ -76,19 +76,6 @@ OPENCL_FORCE_INLINE void Glossy2Material_Evaluate(__global const Material* restr
 	const float3 kdVal = Texture_GetSpectrumValue(material->glossy2.kdTexIndex, hitPoint TEXTURES_PARAM);
 
 	const float3 baseF = Spectrum_Clamp(kdVal) * M_1_PI_F * fabs(lightDir.z);
-	if (eyeDir.z <= 0.f) {
-		// Back face: no coating
-
-		const float directPdfW = fabs(sampledDir.z * M_1_PI_F);
-		const BSDFEvent event = DIFFUSE | REFLECT;
-		const float3 result = baseF;
-
-		EvalStack_PushFloat3(result);
-		EvalStack_PushBSDFEvent(event);
-		EvalStack_PushFloat(directPdfW);
-
-		return;
-	}
 
 	// Front face: coating+base
 	const BSDFEvent event = GLOSSY | REFLECT;
@@ -132,7 +119,7 @@ OPENCL_FORCE_INLINE void Glossy2Material_Evaluate(__global const Material* restr
 	const float3 S = FresnelSchlick_Evaluate(ks, fabs(dot(sampledDir, H)));
 
 	const float3 coatingF = SchlickBSDF_CoatingF(ks, roughness, anisotropy, material->glossy2.multibounce,
-			fixedDir, sampledDir);
+			fixedDir, sampledDir); 
 
 	// Blend in base layer Schlick style
 	// assumes coating bxdf takes fresnel factor S into account
@@ -161,25 +148,6 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 
 	const float3 kdVal = Texture_GetSpectrumValue(material->glossy2.kdTexIndex, hitPoint TEXTURES_PARAM);
 
-	if (fixedDir.z <= 0.f) {
-		// Back Face
-		float pdfW;
-		const float3 sampledDir = -1.f * CosineSampleHemisphereWithPdf(u0, u1, &pdfW);
-		if (fabs(CosTheta(sampledDir)) < DEFAULT_COS_EPSILON_STATIC) {
-			MATERIAL_SAMPLE_RETURN_BLACK;
-		}
-		
-		const BSDFEvent event = DIFFUSE | REFLECT;
-		const float3 result = Spectrum_Clamp(kdVal);
-		
-		EvalStack_PushFloat3(result);
-		EvalStack_PushFloat3(sampledDir);
-		EvalStack_PushFloat(pdfW);
-		EvalStack_PushBSDFEvent(event);
-
-		return;
-	}
-
 	const float3 ksVal = Texture_GetSpectrumValue(material->glossy2.ksTexIndex, hitPoint TEXTURES_PARAM);
 	float3 ks = ksVal;
 	const float i = Texture_GetFloatValue(material->glossy2.indexTexIndex, hitPoint TEXTURES_PARAM);
@@ -192,8 +160,8 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 	const float nuVal = Texture_GetFloatValue(material->glossy2.nuTexIndex, hitPoint TEXTURES_PARAM);
 	const float nvVal = Texture_GetFloatValue(material->glossy2.nvTexIndex, hitPoint TEXTURES_PARAM);
 
-	const float u = clamp(nuVal, 1e-9f, 1.f);
-	const float v = clamp(nvVal, 1e-9f, 1.f);
+	const float u = clamp(nuVal, 1e-5f, 1.f);
+	const float v = clamp(nvVal, 1e-5f, 1.f);
 	const float u2 = u * u;
 	const float v2 = v * v;
 	const float anisotropy = (u2 < v2) ? (1.f - u2 / v2) : u2 > 0.f ? (v2 / u2 - 1.f) : 0.f;
@@ -207,18 +175,13 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 	float basePdf, coatingPdf;
 	float3 baseF, coatingF;
 	if (passThroughEvent < wBase) {
-		// Sample base BSDF (Matte BSDF)
-		baseF = Spectrum_Clamp(kdVal);
-		if (Spectrum_IsBlack(baseF)) {
-			MATERIAL_SAMPLE_RETURN_BLACK;
-		}
 		
 		sampledDir = (signbit(fixedDir.z) ? -1.f : 1.f) * CosineSampleHemisphereWithPdf(u0, u1, &basePdf);
-		if (fabs(CosTheta(sampledDir)) < DEFAULT_COS_EPSILON_STATIC) {
+		if (fabs(sampledDir.z) < DEFAULT_COS_EPSILON_STATIC) {
 			MATERIAL_SAMPLE_RETURN_BLACK;
 		}
 
-		baseF *= basePdf;
+		baseF = Spectrum_Clamp (kdVal) * M_1_PI_F * fabs(sampledDir.z);
 
 		// Evaluate coating BSDF (Schlick BSDF)
 		coatingF = SchlickBSDF_CoatingF(ks, roughness, anisotropy, material->glossy2.multibounce,
@@ -232,7 +195,7 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 			MATERIAL_SAMPLE_RETURN_BLACK;
 		}
 
-		const float absCosSampledDir = fabs(CosTheta(sampledDir));
+		const float absCosSampledDir = fabs(sampledDir.z);
 		if (absCosSampledDir < DEFAULT_COS_EPSILON_STATIC) {
 			MATERIAL_SAMPLE_RETURN_BLACK;
 		}
@@ -241,7 +204,7 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 
 		// Evaluate base BSDF (Matte BSDF)
 		basePdf = absCosSampledDir * M_1_PI_F;
-		baseF = Spectrum_Clamp(kdVal) * basePdf;
+		baseF = Spectrum_Clamp(kdVal) * M_1_PI_F * absCosSampledDir; 
 	}
 
 	const BSDFEvent event = GLOSSY | REFLECT;

--- a/src/slg/materials/material.cpp
+++ b/src/slg/materials/material.cpp
@@ -423,6 +423,7 @@ float slg::SchlickDistribution_G(const float roughness, const Vector &localFixed
 }
 
 static float GetPhi(const float a, const float b) {
+	if ((a < DEFAULT_EPSILON_MIN) || (b < DEFAULT_EPSILON_MIN)) return 0.f;
 	return M_PI * .5f * sqrtf(a * b / (1.f - a * (1.f - b)));
 }
 
@@ -506,13 +507,13 @@ Spectrum slg::SchlickBSDF_CoatingSampleF(const bool fromLight, const Spectrum ks
 	const float cosWH = Dot(localFixedDir, wh);
 	*localSampledDir = 2.f * cosWH * wh - localFixedDir;
 
-	if ((fabsf(localSampledDir->z) < DEFAULT_COS_EPSILON_STATIC) || (localFixedDir.z * localSampledDir->z < 0.f))
+	if ((fabsf (localSampledDir->z) < DEFAULT_COS_EPSILON_STATIC))
 		return Spectrum();
 
 	const float coso = fabsf(localFixedDir.z);
 	const float cosi = fabsf(localSampledDir->z);
 
-	*pdf = specPdf / (4.f * cosWH);
+	*pdf = specPdf / (4.f * fabs (cosWH));
 	if (*pdf <= 0.f)
 		return Spectrum();
 


### PR DESCRIPTION
**Corrected discrepancy between cpu and ocl versions (also crash in cpu version) at low roughnesses**

I know people were complaining (and we also found) that sometimes a GPU render of a glossy surface came out significantly brighter than the same scene on CPU.  I tracked this down to very low roughnesses: at u/v roughness of 0.1, all was fine, but at 0.001 there were often significant differences.  I also found that different GPUs produced different errors: Intel (when it worked at all) was usually correct.  NVidia GeoForce had differences of up to 20%.  

I also found that at very-very low roughnesses (e.g. uroughness = 0.001, vroughness=0) the CPU would crash with an assertion failure caused by a number going denormalised.

The problem was: the code was underflowing on these very low numbers: the GPU brightness was caused by rounding errors and the crash was caused by division-by-nearly zero.  

The roughnesses were clamped to be above 1e-9,  I clamped them to 1e-5, and the problems went away.  (Clamped the same in both CPU and GPU, so they produce the same result).  I've also provided a tiny bit of hardening n the Schlick code.  At some point I want to revise these, so that they're well-behaved down to zero, but for now this avoids the errors and the crash.

**Glossy2 is now double-sided**

Not an error as such, but a real annoyance.  Both in CPU and GPU,  glossy2 had the coating only on the front side; the back side was always matte.  We had a lot of non-volume polygons in our scene, and we wanted them glossy both sides.  As was, we had to duplicate our polys. (Couldn't use two-sided, because the back-side of a two-sided is still the back-side, so can't be made coated using glossy2).

I've now changed that so that glossy2 is coated both sides - if you want it matte on the back, make it two-sided.  I think that, if the material is used either in a manifest poly, or with a volume, there won't be a performance hit because it will never evaluate the coating at the back side because no ray will ever reach it.

Hope these are useful.  