### PR TITLE
Regularise coordinate system

### DIFF
--- a/include/luxrays/core/geometry/vector.h
+++ b/include/luxrays/core/geometry/vector.h
@@ -167,12 +167,11 @@ inline Vector Normalize(const Vector &v) {
 }
 
 inline void CoordinateSystem(const Vector &v1, Vector *v2, Vector *v3) {
-	if (fabsf(v1.x) > fabsf(v1.y)) {
-		float invLen = 1.f / sqrtf(v1.x * v1.x + v1.z * v1.z);
-		*v2 = Vector(-v1.z * invLen, 0.f, v1.x * invLen);
+	float len = sqrtf (v1.y * v1.y + v1.z * v1.z);
+	if (len < 1e-5) { // it's pretty-much along x-axis
+		*v2 = Vector (0.f, 0.f, 1.f);
 	} else {
-		float invLen = 1.f / sqrtf(v1.y * v1.y + v1.z * v1.z);
-		*v2 = Vector(0.f, v1.z * invLen, -v1.y * invLen);
+		*v2 = Vector(0.f, v1.z / len, -v1.y / len);
 	}
 	*v3 = Cross(v1, *v2);
 }

--- a/include/slg/materials/materialdefs_funcs_generic.cl
+++ b/include/slg/materials/materialdefs_funcs_generic.cl
@@ -160,6 +160,7 @@ OPENCL_FORCE_INLINE float SchlickDistribution_G(const float roughness, const flo
 }
 
 OPENCL_FORCE_INLINE float GetPhi(const float a, const float b) {
+	if ((a < DEFAULT_EPSILON_MIN) || (b < DEFAULT_EPSILON_MIN)) return 0.f;
 	return M_PI_F * .5f * sqrt(a * b / (1.f - a * (1.f - b)));
 }
 
@@ -254,13 +255,13 @@ OPENCL_FORCE_INLINE float3 SchlickBSDF_CoatingSampleF(const float3 ks,
 	const float cosWH = dot(fixedDir, wh);
 	*sampledDir = 2.f * cosWH * wh - fixedDir;
 
-	if ((fabs((*sampledDir).z) < DEFAULT_COS_EPSILON_STATIC) || (fixedDir.z * (*sampledDir).z < 0.f))
+	if ((fabs((*sampledDir).z) < DEFAULT_COS_EPSILON_STATIC))
 		return BLACK;
 
 	const float coso = fabs(fixedDir.z);
 	const float cosi = fabs((*sampledDir).z);
 
-	*pdf = specPdf / (4.f * cosWH);
+	*pdf = specPdf / (4.f * fabs (cosWH));
 	if (*pdf <= 0.f)
 		return BLACK;
 

--- a/include/slg/materials/materialdefs_funcs_glossy2.cl
+++ b/include/slg/materials/materialdefs_funcs_glossy2.cl
@@ -76,19 +76,6 @@ OPENCL_FORCE_INLINE void Glossy2Material_Evaluate(__global const Material* restr
 	const float3 kdVal = Texture_GetSpectrumValue(material->glossy2.kdTexIndex, hitPoint TEXTURES_PARAM);
 
 	const float3 baseF = Spectrum_Clamp(kdVal) * M_1_PI_F * fabs(lightDir.z);
-	if (eyeDir.z <= 0.f) {
-		// Back face: no coating
-
-		const float directPdfW = fabs(sampledDir.z * M_1_PI_F);
-		const BSDFEvent event = DIFFUSE | REFLECT;
-		const float3 result = baseF;
-
-		EvalStack_PushFloat3(result);
-		EvalStack_PushBSDFEvent(event);
-		EvalStack_PushFloat(directPdfW);
-
-		return;
-	}
 
 	// Front face: coating+base
 	const BSDFEvent event = GLOSSY | REFLECT;
@@ -132,7 +119,7 @@ OPENCL_FORCE_INLINE void Glossy2Material_Evaluate(__global const Material* restr
 	const float3 S = FresnelSchlick_Evaluate(ks, fabs(dot(sampledDir, H)));
 
 	const float3 coatingF = SchlickBSDF_CoatingF(ks, roughness, anisotropy, material->glossy2.multibounce,
-			fixedDir, sampledDir);
+			fixedDir, sampledDir); 
 
 	// Blend in base layer Schlick style
 	// assumes coating bxdf takes fresnel factor S into account
@@ -161,25 +148,6 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 
 	const float3 kdVal = Texture_GetSpectrumValue(material->glossy2.kdTexIndex, hitPoint TEXTURES_PARAM);
 
-	if (fixedDir.z <= 0.f) {
-		// Back Face
-		float pdfW;
-		const float3 sampledDir = -1.f * CosineSampleHemisphereWithPdf(u0, u1, &pdfW);
-		if (fabs(CosTheta(sampledDir)) < DEFAULT_COS_EPSILON_STATIC) {
-			MATERIAL_SAMPLE_RETURN_BLACK;
-		}
-		
-		const BSDFEvent event = DIFFUSE | REFLECT;
-		const float3 result = Spectrum_Clamp(kdVal);
-		
-		EvalStack_PushFloat3(result);
-		EvalStack_PushFloat3(sampledDir);
-		EvalStack_PushFloat(pdfW);
-		EvalStack_PushBSDFEvent(event);
-
-		return;
-	}
-
 	const float3 ksVal = Texture_GetSpectrumValue(material->glossy2.ksTexIndex, hitPoint TEXTURES_PARAM);
 	float3 ks = ksVal;
 	const float i = Texture_GetFloatValue(material->glossy2.indexTexIndex, hitPoint TEXTURES_PARAM);
@@ -192,8 +160,8 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 	const float nuVal = Texture_GetFloatValue(material->glossy2.nuTexIndex, hitPoint TEXTURES_PARAM);
 	const float nvVal = Texture_GetFloatValue(material->glossy2.nvTexIndex, hitPoint TEXTURES_PARAM);
 
-	const float u = clamp(nuVal, 1e-9f, 1.f);
-	const float v = clamp(nvVal, 1e-9f, 1.f);
+	const float u = clamp(nuVal, 1e-5f, 1.f);
+	const float v = clamp(nvVal, 1e-5f, 1.f);
 	const float u2 = u * u;
 	const float v2 = v * v;
 	const float anisotropy = (u2 < v2) ? (1.f - u2 / v2) : u2 > 0.f ? (v2 / u2 - 1.f) : 0.f;
@@ -207,18 +175,13 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 	float basePdf, coatingPdf;
 	float3 baseF, coatingF;
 	if (passThroughEvent < wBase) {
-		// Sample base BSDF (Matte BSDF)
-		baseF = Spectrum_Clamp(kdVal);
-		if (Spectrum_IsBlack(baseF)) {
-			MATERIAL_SAMPLE_RETURN_BLACK;
-		}
 		
 		sampledDir = (signbit(fixedDir.z) ? -1.f : 1.f) * CosineSampleHemisphereWithPdf(u0, u1, &basePdf);
-		if (fabs(CosTheta(sampledDir)) < DEFAULT_COS_EPSILON_STATIC) {
+		if (fabs(sampledDir.z) < DEFAULT_COS_EPSILON_STATIC) {
 			MATERIAL_SAMPLE_RETURN_BLACK;
 		}
 
-		baseF *= basePdf;
+		baseF = Spectrum_Clamp (kdVal) * M_1_PI_F * fabs(sampledDir.z);
 
 		// Evaluate coating BSDF (Schlick BSDF)
 		coatingF = SchlickBSDF_CoatingF(ks, roughness, anisotropy, material->glossy2.multibounce,
@@ -232,7 +195,7 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 			MATERIAL_SAMPLE_RETURN_BLACK;
 		}
 
-		const float absCosSampledDir = fabs(CosTheta(sampledDir));
+		const float absCosSampledDir = fabs(sampledDir.z);
 		if (absCosSampledDir < DEFAULT_COS_EPSILON_STATIC) {
 			MATERIAL_SAMPLE_RETURN_BLACK;
 		}
@@ -241,7 +204,7 @@ OPENCL_FORCE_INLINE void Glossy2Material_Sample(__global const Material* restric
 
 		// Evaluate base BSDF (Matte BSDF)
 		basePdf = absCosSampledDir * M_1_PI_F;
-		baseF = Spectrum_Clamp(kdVal) * basePdf;
+		baseF = Spectrum_Clamp(kdVal) * M_1_PI_F * absCosSampledDir; 
 	}
 
 	const BSDFEvent event = GLOSSY | REFLECT;

--- a/src/slg/materials/material.cpp
+++ b/src/slg/materials/material.cpp
@@ -423,6 +423,7 @@ float slg::SchlickDistribution_G(const float roughness, const Vector &localFixed
 }
 
 static float GetPhi(const float a, const float b) {
+	if ((a < DEFAULT_EPSILON_MIN) || (b < DEFAULT_EPSILON_MIN)) return 0.f;
 	return M_PI * .5f * sqrtf(a * b / (1.f - a * (1.f - b)));
 }
 
@@ -506,13 +507,13 @@ Spectrum slg::SchlickBSDF_CoatingSampleF(const bool fromLight, const Spectrum ks
 	const float cosWH = Dot(localFixedDir, wh);
 	*localSampledDir = 2.f * cosWH * wh - localFixedDir;
 
-	if ((fabsf(localSampledDir->z) < DEFAULT_COS_EPSILON_STATIC) || (localFixedDir.z * localSampledDir->z < 0.f))
+	if ((fabsf (localSampledDir->z) < DEFAULT_COS_EPSILON_STATIC))
 		return Spectrum();
 
 	const float coso = fabsf(localFixedDir.z);
 	const float cosi = fabsf(localSampledDir->z);
 
-	*pdf = specPdf / (4.f * cosWH);
+	*pdf = specPdf / (4.f * fabs (cosWH));
 	if (*pdf <= 0.f)
 		return Spectrum();
 


### PR DESCRIPTION
Sorry about the very long explanation of a very simple fix.

In material::Evaluate and ::Sample, the light and eye rays are expressed in a coordinate system which is local to the polygon: to a first approximation the normal to the polygon is aligned along z.  Where the polygon carries a u or v, u is aligned along x in the local frame, and v is aligned along y.  So far, so good.

But if the poly doesn't provide u and v, then Frame calls Vector::CoordinateSystem to invent one.  It uses the polygon normal to create an orthogonal basis.  But: there are two bases it could make: one where u is located somewhere on the y=0 plane, and another where v is located on x=0.  It chooses based on the direction of the normal.

That means, in turn, that inside ::Evaluate and ::Sample, the light and eye rays can appear in one of two frames, with no way to find out which.  So long as the material is anisotropic, this doesn't matter.  But if the material is isotropic, it matters very much, because the isotropy "grain" switches across the face of polygon, creating very objectionable seams.

I was working with some highly isotropic materials, but even with the stock materials you can see it.  Create a glossy2 or a metal with uroughness=0.7 and vroughness = 0.1, and render a ball.  You can see the streaky reflections quite clearly, but you'll also see the seams around it.

This mod selects the frame where v points as vertically in world space as possible (no matter the orientation of the poly) - that is: it selects v in x=0.   Where the poly faces directly upwards, it adopts a standard frame, also where v=0.  Inside ::Evaluate and ::Sample the local frame's y will always point generally vertically in world space.

The change should be invisible to anisotropic materials, and should improve isotropic ones.