### PR TITLE
Fix misc. source comment typos

### DIFF
--- a/include/slg/bsdf/hitpoint.h
+++ b/include/slg/bsdf/hitpoint.h
@@ -72,7 +72,7 @@ typedef struct {
 	const Volume *interiorVolume, *exteriorVolume;
 	u_int objectID;
 	bool fromLight, intoObject;
-	// If I got here going trough a shadow transparency. It can be used to disable MIS.
+	// If I got here going through a shadow transparency. It can be used to disable MIS.
 	bool throughShadowTransparency;
 
 	// Used when hitting a surface

--- a/include/slg/engines/pathoclbase/kernels/pathoclbase_funcs.cl
+++ b/include/slg/engines/pathoclbase/kernels/pathoclbase_funcs.cl
@@ -140,7 +140,7 @@ OPENCL_FORCE_INLINE void GenerateEyePath(
 	taskState->photonGICacheEnabledOnLastHit = false;
 	taskState->photonGICausticCacheUsed = false;
 	taskState->photonGIShowIndirectPathMixUsed = false;
-	// Initialize the trough a shadow transparency flag used by Scene_Intersect()
+	// Initialize the through a shadow transparency flag used by Scene_Intersect()
 	taskState->throughShadowTransparency = false;
 
 	// Initialize the pass-through event seed

--- a/include/slg/engines/pathoclbase/kernels/pathoclbase_kernels_micro.cl
+++ b/include/slg/engines/pathoclbase/kernels/pathoclbase_kernels_micro.cl
@@ -697,7 +697,7 @@ __kernel void AdvancePaths_MK_DL_SAMPLE_BSDF(
 		// Save the seed
 		task->seed = seedValue;
 
-		// Initialize the trough a shadow transparency flag used by Scene_Intersect()
+		// Initialize the through a shadow transparency flag used by Scene_Intersect()
 		tasksDirectLight[gid].throughShadowTransparency = false;
 
 		// Make a copy of current PathVolumeInfo for tracing the
@@ -854,7 +854,7 @@ __kernel void AdvancePaths_MK_GENERATE_NEXT_VERTEX_RAY(
 		Rnd_InitFloat(passThroughEvent, &seedPassThroughEvent);
 		taskState->seedPassThroughEvent = seedPassThroughEvent;
 
-		// Initialize the trough a shadow transparency flag used by Scene_Intersect()
+		// Initialize the through a shadow transparency flag used by Scene_Intersect()
 		taskState->throughShadowTransparency = false;
 
 

--- a/src/slg/engines/caches/photongi/photongicache.cpp
+++ b/src/slg/engines/caches/photongi/photongicache.cpp
@@ -379,7 +379,7 @@ void PhotonGICache::Preprocess(const u_int threadCnt) {
 			return;
 		}
 		
-		// The file doesn't exist so I have to go trough normal pre-processing
+		// The file doesn't exist so I have to go through normal pre-processing
 	}
 
 	//--------------------------------------------------------------------------

--- a/src/slg/lights/strategies/dlscacheimpl/dlscacheimpl.cpp
+++ b/src/slg/lights/strategies/dlscacheimpl/dlscacheimpl.cpp
@@ -487,7 +487,7 @@ void DirectLightSamplingCache::Build(const Scene *scn) {
 			return;
 		}
 		
-		// The file doesn't exist so I have to go trough normal pre-processing
+		// The file doesn't exist so I have to go through normal pre-processing
 	}
 
 	//--------------------------------------------------------------------------

--- a/src/slg/lights/visibility/envlightvisibilitycache.cpp
+++ b/src/slg/lights/visibility/envlightvisibilitycache.cpp
@@ -669,7 +669,7 @@ void EnvLightVisibilityCache::Build() {
 			return;
 		}
 		
-		// The file doesn't exist so I have to go trough normal pre-processing
+		// The file doesn't exist so I have to go through normal pre-processing
 	}
 
 	ParamsEvaluation();

--- a/src/slg/shapes/displacement.cpp
+++ b/src/slg/shapes/displacement.cpp
@@ -53,7 +53,7 @@ DisplacementShape::DisplacementShape(luxrays::ExtTriangleMesh *srcMesh, const Te
 
 	vector<u_int> triangleIndex(vertCount);
 
-	// Go trough the faces and save the information
+	// Go through the faces and save the information
 	vector<bool> doneVerts(vertCount, false);
 	const u_int triCount = srcMesh->GetTotalTriangleCount();
 	const Triangle *tris = srcMesh->GetTriangles();

--- a/src/slg/textures/blender_noiselib.cpp
+++ b/src/slg/textures/blender_noiselib.cpp
@@ -25,7 +25,7 @@ namespace blender {
 
 /*
  * NOTE: This code is not thread safe and should been replaced by the usage
- * pass trough random variable in procedural textures
+ * pass through random variable in procedural textures
  */
 
 typedef unsigned long long r_uint64;


### PR DESCRIPTION
Found via `codespell -q 3 -S ./deps,./samples/luxcoreui/deps -L anumber,avarage,ba,currenty,datas,efficency,heterogenous,homogenous,iterm,lod,mapp,mata,mot,pixelx,pres,relfected,warmup`