### PR TITLE
deps/spdlog: fix conversion from const string to const char*

### DIFF
--- a/deps/spdlog-1.8.0/include/spdlog/common-inl.h
+++ b/deps/spdlog-1.8.0/include/spdlog/common-inl.h
@@ -54,7 +54,7 @@ SPDLOG_INLINE spdlog_ex::spdlog_ex(std::string msg)
 SPDLOG_INLINE spdlog_ex::spdlog_ex(const std::string &msg, int last_errno)
 {
     memory_buf_t outbuf;
-    fmt::format_system_error(outbuf, last_errno, msg);
+    fmt::format_system_error(outbuf, last_errno, msg.c_str());
     msg_ = fmt::to_string(outbuf);
 }
 


### PR DESCRIPTION
Fixes:
  
```
In file included from LuxCore/deps/spdlog-1.8.0/include/spdlog/common.h:245,
                 from LuxCore/deps/spdlog-1.8.0/include/spdlog/spdlog.h:12,
                 from LuxCore/src/luxcore/luxcore.cpp:22:
LuxCore/deps/spdlog-1.8.0/include/spdlog/common-inl.h: In constructor ‘spdlog::spdlog_ex::spdlog_ex(const string&, int)’:
LuxCore/deps/spdlog-1.8.0/include/spdlog/common-inl.h:57:50: error: cannot convert ‘const string’ {aka ‘const std::__cxx11::basic_string<char>’} to ‘const char*’
   57 |     fmt::format_system_error(outbuf, last_errno, msg);
      |                                                  ^~~
      |                                                  |
      |                                                  const string {aka const std::__cxx11::basic_string<char>}
```

It looks like this is [fixed upstream](https://github.com/gabime/spdlog/blob/3c0e036cc9e12664e2b757fd17fdba42f6f19f90/include/spdlog/common-inl.h#L62) so one may prefer to update the deps instead, but this patch fixes the bug with less effort until someone looks at updating deps.

This work is courtesy of [I ♥ Compute](https://gitlab.com/illwieckz/i-love-compute) initiative funded by [🇫🇷️ rebatir.fr](https://rebatir.fr/).