### PR TITLE
slg/bakecputhread: fix ambiguous _1 placeholder references

### DIFF
--- a/src/slg/engines/bakecpu/bakecputhread.cpp
+++ b/src/slg/engines/bakecpu/bakecputhread.cpp
@@ -356,7 +356,7 @@ void BakeCPURenderThread::RenderLightSample(const BakeMapInfo &mapInfo, PathTrac
 	const PathTracer &pathTracer = engine->pathTracer;
 	
 	const PathTracer::ConnectToEyeCallBackType connectToEyeCallBack = boost::bind(
-			&BakeCPURenderThread::RenderConnectToEyeCallBack, this, mapInfo, _1, _2, _3, _4, _5);
+			&BakeCPURenderThread::RenderConnectToEyeCallBack, this, mapInfo, boost::placeholders::_1, boost::placeholders::_2, boost::placeholders::_3, boost::placeholders::_4, boost::placeholders::_5);
 
 	pathTracer.RenderLightSample(state.device, state.scene, state.film, state.lightSampler,
 			state.lightSampleResults, connectToEyeCallBack);


### PR DESCRIPTION
Fixes:

```
LuxCore/src/slg/engines/bakecpu/bakecputhread.cpp: In member function ‘void slg::BakeCPURenderThread::RenderLightSample(const slg::BakeMapInfo&, slg::PathTracerThreadState&) const’:
LuxCore/src/slg/engines/bakecpu/bakecputhread.cpp:359:90: error: ‘_1’ was not declared in this scope
  359 |               &BakeCPURenderThread::RenderConnectToEyeCallBack, this, mapInfo, _1, _2, _3, _4, _5);
      |                                                                                ^~

LuxCore/src/slg/engines/bakecpu/bakecputhread.cpp:359:90: note: suggested alternatives:
/usr/include/boost/mpl/aux_/preprocessed/gcc/placeholders.hpp:29:16: note:   ‘mpl_::_1’
   29 | typedef arg<1> _1;
      |                ^~
/usr/include/c++/11/functional:225:34: note:   ‘std::placeholders::_1’
  225 |     extern const _Placeholder<1> _1;
      |                                  ^~
/usr/include/boost/bind/placeholders.hpp:46:38: note:   ‘boost::placeholders::_1’
   46 | BOOST_STATIC_CONSTEXPR boost::arg<1> _1;
      |                                      ^~
/usr/include/boost/mp11/bind.hpp:45:7: note:   ‘boost::mp11::_1’
   45 | using _1 = mp_arg<0>;
      |       ^~
```