### PR TITLE
slg/filmserialize: fix unknown library_version_type from boost::serialization

### DIFF
--- a/src/slg/film/filmserialize.cpp
+++ b/src/slg/film/filmserialize.cpp
@@ -20,6 +20,7 @@
 
 #include <boost/lexical_cast.hpp>
 #include <boost/foreach.hpp>
+#include <boost/serialization/library_version_type.hpp>
 #include <boost/serialization/unordered_set.hpp>
 
 #include "slg/film/film.h"


### PR DESCRIPTION
When I wrote https://github.com/LuxCoreRender/LuxCore/pull/596 (still to be merged) and https://github.com/LuxCoreRender/LuxCore/pull/597 I also wrote this patch but I forgot to submit this one.

This work is courtesy of [I ♥ Compute](https://gitlab.com/illwieckz/i-love-compute) initiative funded by [🇫🇷️ rebatir.fr](https://rebatir.fr/).