### PR TITLE
deps/opencolorio: fix missing cstring header

### DIFF
--- a/deps/opencolorio-2.0.0/src/OpenColorIO/FileRules.cpp
+++ b/deps/opencolorio-2.0.0/src/OpenColorIO/FileRules.cpp
@@ -14,6 +14,7 @@
 #include "PathUtils.h"
 #include "Platform.h"
 #include "utils/StringUtils.h"
+#include <cstring>
 
 
 namespace OCIO_NAMESPACE


### PR DESCRIPTION
This fixes this build error:

```
LuxCore/deps/opencolorio-2.0.0/src/OpenColorIO/FileRules.cpp: In function ‘std::string OpenColorIO_v2_0::{anonymous}::ConvertToRegularExpression(const char*, bool)’:
LuxCore/deps/opencolorio-2.0.0/src/OpenColorIO/FileRules.cpp:63:31: error: ‘strlen’ was not declared in this scope
   63 |         const size_t length = strlen(globPattern);
      |                               ^~~~~~
LuxCore/deps/opencolorio-2.0.0/src/OpenColorIO/FileRules.cpp:17:1: note: ‘strlen’ is defined in header ‘<cstring>’; did you forget to ‘#include <cstring>’?
```

Like #596 one may want to look for an upstream fix if exists, but this patch fixes the bug with less effort until someone looks at updating deps.

This work is courtesy of [I ♥ Compute](https://gitlab.com/illwieckz/i-love-compute) initiative funded by [🇫🇷️ rebatir.fr](https://rebatir.fr/).